### PR TITLE
[FEAT] 주문 모듈 상품 읽기 전용 테이블 구현 완료

### DIFF
--- a/common/src/main/java/com/thock/back/shared/product/event/ProductEvent.java
+++ b/common/src/main/java/com/thock/back/shared/product/event/ProductEvent.java
@@ -11,6 +11,7 @@ public record ProductEvent(
         Long salePrice,
         String description,
         Integer stock,
+        Integer reservedStock,
         String imageUrl,
         String productState,
         ProductEventType eventType  // "CREATE", "UPDATE", "DELETE"

--- a/loadtest/cart-read-cqrs.js
+++ b/loadtest/cart-read-cqrs.js
@@ -1,0 +1,325 @@
+import http from 'k6/http';
+import { check, fail, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+
+const cartReads = new Counter('cart_reads_total');
+const cartReadFailures = new Counter('cart_read_failures_total');
+
+const experimentRunId = __ENV.RUN_ID || `${Date.now()}`;
+const rate = Number(__ENV.RATE || 50);
+const preAllocatedVUs = Number(__ENV.PRE_ALLOCATED_VUS || 50);
+const maxVUs = Number(__ENV.MAX_VUS || 100);
+const sleepBetween = Number(__ENV.SLEEP_BETWEEN || 0);
+const productIds = (__ENV.PRODUCT_IDS || '1,2,3')
+  .split(',')
+  .map((value) => Number(value.trim()))
+  .filter((value) => Number.isFinite(value) && value > 0);
+const cartItemQuantity = Number(__ENV.CART_ITEM_QUANTITY || 1);
+
+export const options = {
+  scenarios: {
+    cart_read_load: {
+      executor: 'constant-arrival-rate',
+      rate,
+      timeUnit: '1s',
+      duration: __ENV.DURATION || '1m',
+      preAllocatedVUs,
+      maxVUs,
+      gracefulStop: '5s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    http_req_duration: ['p(95)<2000'],
+    checks: ['rate>0.99'],
+  },
+};
+
+export function setup() {
+  if (productIds.length === 0) {
+    fail('PRODUCT_IDS must contain at least one valid product id.');
+  }
+
+  const baseUrl = (__ENV.BASE_URL || 'http://api-gateway:8080').replace(/\/$/, '');
+  const password = __ENV.PASSWORD || 'password123!';
+  const runId = experimentRunId;
+  const buyerEmail = __ENV.BUYER_EMAIL || `buyer-k6-${runId}@example.com`;
+  const buyerName = __ENV.BUYER_NAME || `buyer-k6-${runId}`;
+
+  let accessToken = __ENV.BUYER_ACCESS_TOKEN;
+  if (!accessToken) {
+    signUp(baseUrl, buyerEmail, buyerName, password);
+    sleep(0.5);
+    accessToken = login(baseUrl, buyerEmail, password);
+  }
+
+  waitForCartReady(baseUrl, accessToken);
+  clearCart(baseUrl, accessToken);
+  seedCart(baseUrl, accessToken, productIds, cartItemQuantity);
+  verifyCart(baseUrl, accessToken, productIds);
+
+  return {
+    accessToken,
+    baseUrl,
+    runId,
+    buyerEmail,
+  };
+}
+
+export default function (data) {
+  const response = http.get(`${data.baseUrl}/api/v1/carts`, {
+    headers: {
+      Authorization: `Bearer ${data.accessToken}`,
+    },
+    tags: {
+      name: 'get_cart_items',
+      experiment: __ENV.EXPERIMENT_NAME || 'cart-read-load',
+    },
+  });
+
+  const passed = check(response, {
+    'get cart status is 200': (res) => res.status === 200,
+    'get cart returns items': (res) => {
+      if (res.status !== 200) {
+        return false;
+      }
+
+      const payload = res.json();
+      return payload && Array.isArray(payload.items) && payload.items.length >= productIds.length;
+    },
+  });
+
+  if (passed) {
+    cartReads.add(1);
+  } else {
+    cartReadFailures.add(1);
+  }
+
+  if (sleepBetween > 0) {
+    sleep(sleepBetween);
+  }
+}
+
+export function handleSummary(data) {
+  const summaryPath = __ENV.SUMMARY_PATH || '/results/cart-read-summary.json';
+  const buyerEmail = __ENV.BUYER_EMAIL || `buyer-k6-${experimentRunId}@example.com`;
+
+  return {
+    stdout: [
+      '',
+      `experiment=${__ENV.EXPERIMENT_NAME || 'cart-read-load'}`,
+      `run_id=${experimentRunId}`,
+      `buyer_email=${buyerEmail}`,
+      `product_ids=${productIds.join(',')}`,
+      `http_req_failed_rate=${formatMetricValue(data.metrics.http_req_failed, 'rate')}`,
+      `http_req_duration_avg=${formatMetricValue(data.metrics.http_req_duration, 'avg')}ms`,
+      `http_req_duration_p95=${formatMetricValue(data.metrics.http_req_duration, 'p(95)')}ms`,
+      `http_reqs_count=${formatMetricValue(data.metrics.http_reqs, 'count')}`,
+      `http_reqs_rate=${formatMetricValue(data.metrics.http_reqs, 'rate')}`,
+      `cart_reads_total=${formatMetricValue(data.metrics.cart_reads_total, 'count')}`,
+      `cart_read_failures_total=${formatMetricValue(data.metrics.cart_read_failures_total, 'count')}`,
+      '',
+    ].join('\n'),
+    [summaryPath]: JSON.stringify(data, null, 2),
+  };
+}
+
+function signUp(baseUrl, email, name, password) {
+  const response = requestWithRetry(() =>
+    http.post(
+      `${baseUrl}/api/v1/members/signup`,
+      JSON.stringify({ email, name, password }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        tags: { name: 'signup' },
+      }
+    ),
+    {
+      action: 'signup',
+      expectedStatuses: [201, 409],
+      retryOnStatuses: [500, 502, 503, 504],
+    }
+  );
+
+  if (response.status !== 201 && response.status !== 409) {
+    fail(`signup failed: status=${response.status} body=${response.body}`);
+  }
+}
+
+function login(baseUrl, email, password) {
+  const response = requestWithRetry(() =>
+    http.post(
+      `${baseUrl}/api/v1/auth/login`,
+      JSON.stringify({ email, password }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        tags: { name: 'login' },
+      }
+    ),
+    {
+      action: 'login',
+      expectedStatuses: [200],
+      retryOnStatuses: [500, 502, 503, 504],
+      maxAttempts: 6,
+      backoffSeconds: 1,
+    }
+  );
+
+  if (!response || response.status !== 200) {
+    fail(`login failed: status=${response.status} body=${response.body}`);
+  }
+
+  const payload = response.json();
+  if (!payload.accessToken) {
+    fail(`login response does not contain accessToken: body=${response.body}`);
+  }
+
+  return payload.accessToken;
+}
+
+function waitForCartReady(baseUrl, accessToken) {
+  const maxAttempts = Number(__ENV.CART_READY_MAX_ATTEMPTS || 20);
+  const backoffSeconds = Number(__ENV.CART_READY_BACKOFF_SECONDS || 1);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const response = http.get(`${baseUrl}/api/v1/carts`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      tags: {
+        name: 'wait_cart_ready',
+      },
+    });
+
+    if (response.status === 200) {
+      return;
+    }
+
+    if (attempt === maxAttempts) {
+      fail(`cart was not ready: status=${response.status} body=${response.body}`);
+    }
+
+    sleep(backoffSeconds);
+  }
+}
+
+function clearCart(baseUrl, accessToken) {
+  const response = requestWithRetry(() =>
+    http.del(
+      `${baseUrl}/api/v1/carts/items`,
+      JSON.stringify([]),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        tags: { name: 'clear_cart' },
+      }
+    ),
+    {
+      action: 'clear cart',
+      expectedStatuses: [204],
+      retryOnStatuses: [404, 500, 502, 503, 504],
+      maxAttempts: 6,
+      backoffSeconds: 1,
+    }
+  );
+
+  if (response.status !== 204) {
+    fail(`clear cart failed: status=${response.status} body=${response.body}`);
+  }
+}
+
+function seedCart(baseUrl, accessToken, productIdsToSeed, quantity) {
+  for (const productId of productIdsToSeed) {
+    const response = requestWithRetry(() =>
+      http.post(
+        `${baseUrl}/api/v1/carts/items`,
+        JSON.stringify({ productId, quantity }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${accessToken}`,
+          },
+          tags: { name: 'seed_cart_item' },
+        }
+      ),
+      {
+        action: `seed cart productId=${productId}`,
+        expectedStatuses: [201],
+        retryOnStatuses: [404, 409, 500, 502, 503, 504],
+        maxAttempts: 6,
+        backoffSeconds: 1,
+      }
+    );
+
+    if (response.status !== 201) {
+      fail(`seed cart failed: productId=${productId} status=${response.status} body=${response.body}`);
+    }
+  }
+}
+
+function verifyCart(baseUrl, accessToken, expectedProductIds) {
+  const response = http.get(`${baseUrl}/api/v1/carts`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    tags: { name: 'verify_cart' },
+  });
+
+  if (response.status !== 200) {
+    fail(`verify cart failed: status=${response.status} body=${response.body}`);
+  }
+
+  const payload = response.json();
+  const actualProductIds = (payload.items || []).map((item) => item.productId);
+  for (const productId of expectedProductIds) {
+    if (!actualProductIds.includes(productId)) {
+      fail(`cart does not contain expected productId=${productId}: body=${response.body}`);
+    }
+  }
+}
+
+function requestWithRetry(requestFn, options = {}) {
+  const {
+    action = 'request',
+    expectedStatuses = [200],
+    retryOnStatuses = [500, 502, 503, 504],
+    maxAttempts = 5,
+    backoffSeconds = 0.5,
+  } = options;
+
+  let lastResponse = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    lastResponse = requestFn();
+
+    if (lastResponse && expectedStatuses.includes(lastResponse.status)) {
+      return lastResponse;
+    }
+
+    const shouldRetry =
+      !lastResponse ||
+      retryOnStatuses.includes(lastResponse.status) ||
+      lastResponse.error_code !== 0;
+
+    if (!shouldRetry || attempt === maxAttempts) {
+      return lastResponse;
+    }
+
+    console.warn(
+      `${action} retrying: attempt=${attempt} status=${lastResponse.status} error=${lastResponse.error}`
+    );
+    sleep(backoffSeconds * attempt);
+  }
+
+  return lastResponse;
+}
+
+function formatMetricValue(metric, key) {
+  if (!metric || !metric.values || metric.values[key] === undefined) {
+    return '0';
+  }
+
+  return Number(metric.values[key]).toFixed(2);
+}

--- a/loadtest/run-cart-read-experiment.sh
+++ b/loadtest/run-cart-read-experiment.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+RUN_ID="${RUN_ID:-$(date +%s)}"
+EXPERIMENT_NAME="${EXPERIMENT_NAME:-cart-read-load}"
+SUMMARY_PATH="${SUMMARY_PATH:-/results/${EXPERIMENT_NAME}-${RUN_ID}.json}"
+GATEWAY_HEALTH_URL="${GATEWAY_HEALTH_URL:-http://localhost:8080/actuator/health}"
+WAIT_MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS:-30}"
+WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS:-2}"
+BUYER_EMAIL="${BUYER_EMAIL:-buyer-k6-${RUN_ID}@example.com}"
+BUYER_NAME="${BUYER_NAME:-buyer-k6-${RUN_ID}}"
+
+docker compose up -d mysql redpanda member-service product-service market-service api-gateway
+
+wait_for_gateway() {
+  local attempt=1
+  while (( attempt <= WAIT_MAX_ATTEMPTS )); do
+    if command -v curl >/dev/null 2>&1; then
+      if curl -fsS "${GATEWAY_HEALTH_URL}" >/dev/null 2>&1; then
+        echo "gateway_ready=true"
+        return 0
+      fi
+    elif command -v wget >/dev/null 2>&1; then
+      if wget -qO- "${GATEWAY_HEALTH_URL}" >/dev/null 2>&1; then
+        echo "gateway_ready=true"
+        return 0
+      fi
+    else
+      echo "Neither curl nor wget is available on the host." >&2
+      return 1
+    fi
+
+    echo "gateway_ready=false attempt=${attempt} url=${GATEWAY_HEALTH_URL}"
+    sleep "${WAIT_SLEEP_SECONDS}"
+    attempt=$((attempt + 1))
+  done
+
+  echo "Gateway did not become ready: ${GATEWAY_HEALTH_URL}" >&2
+  return 1
+}
+
+wait_for_gateway
+
+cat <<EOF
+experiment=${EXPERIMENT_NAME}
+run_id=${RUN_ID}
+buyer_email=${BUYER_EMAIL}
+buyer_password=${K6_PASSWORD:-password123!}
+product_ids=${PRODUCT_IDS:-1,2,3}
+rate=${K6_RATE:-50}
+duration=${K6_DURATION:-1m}
+EOF
+
+docker compose --profile loadtest run --rm \
+  -e RUN_ID="${RUN_ID}" \
+  -e EXPERIMENT_NAME="${EXPERIMENT_NAME}" \
+  -e SUMMARY_PATH="${SUMMARY_PATH}" \
+  -e BASE_URL="${K6_BASE_URL:-http://api-gateway:8080}" \
+  -e PASSWORD="${K6_PASSWORD:-password123!}" \
+  -e BUYER_EMAIL="${BUYER_EMAIL}" \
+  -e BUYER_NAME="${BUYER_NAME}" \
+  -e BUYER_ACCESS_TOKEN="${BUYER_ACCESS_TOKEN:-}" \
+  -e RATE="${K6_RATE:-50}" \
+  -e DURATION="${K6_DURATION:-1m}" \
+  -e PRE_ALLOCATED_VUS="${K6_PRE_ALLOCATED_VUS:-50}" \
+  -e MAX_VUS="${K6_MAX_VUS:-100}" \
+  -e PRODUCT_IDS="${PRODUCT_IDS:-1,2,3}" \
+  -e CART_ITEM_QUANTITY="${K6_CART_ITEM_QUANTITY:-1}" \
+  -e SLEEP_BETWEEN="${K6_SLEEP_BETWEEN:-0}" \
+  k6 run /scripts/cart-read-cqrs.js

--- a/market-service/src/main/java/com/thock/back/market/app/CartService.java
+++ b/market-service/src/main/java/com/thock/back/market/app/CartService.java
@@ -5,6 +5,8 @@ import com.thock.back.global.exception.CustomException;
 import com.thock.back.global.exception.ErrorCode;
 import com.thock.back.market.domain.Cart;
 import com.thock.back.market.domain.CartItem;
+import com.thock.back.market.domain.CartProductView;
+import com.thock.back.market.domain.CartProductViewRepository;
 import com.thock.back.market.domain.MarketMember;
 import com.thock.back.market.in.dto.req.CartItemAddRequest;
 import com.thock.back.market.in.dto.res.CartItemListResponse;
@@ -18,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class CartService {
     private final MarketSupport marketSupport;
+    private final CartProductViewRepository cartProductViewRepository;
 
     // 장바구니 조회
     @Transactional(readOnly = true)
@@ -49,40 +51,21 @@ public class CartService {
                 .map(CartItem::getProductId)
                 .toList();
 
-        // 여러 개 조회 : getProducts() 사용
-        List<ProductInfo> products = marketSupport.getProducts(productIds);
-
-        // Map으로 변환
-        Map<Long, ProductInfo> productMap = products.stream()
-                .collect(Collectors.toMap(ProductInfo::getId, Function.identity()));
+        List<CartProductView> products = cartProductViewRepository.findAllByProductIdIn(productIds);
+        Map<Long, CartProductView> productMap = products.stream()
+                .collect(Collectors.toMap(CartProductView::getProductId, product -> product));
 
         // CartItemResponse 생성
         List<CartItemResponse> items = cart.getItems().stream()
                 .map(cartItem -> {
-                    ProductInfo product = productMap.get(cartItem.getProductId());
+                    CartProductView product = productMap.get(cartItem.getProductId());
 
                     if (product == null) {
-                        log.warn("장바구니에 있지만 상품 정보가 없음: productId={}", cartItem.getProductId());
+                        log.warn("장바구니에 있지만 CQRS projection이 없음: productId={}", cartItem.getProductId());
                         return null;
                     }
 
-                    Long totalPrice = cartItem.getQuantity() * product.getPrice();
-                    Long totalSalePrice = cartItem.getQuantity() * product.getSalePrice();
-                    Long discountAmount = totalPrice - totalSalePrice;
-
-                    return new CartItemResponse(
-                            cartItem.getId(),
-                            cartItem.getQuantity(),
-                            product.getId(),
-                            product.getName(),
-                            product.getImageUrl(),
-                            product.getPrice(),
-                            product.getSalePrice(),
-                            product.availableStock(),
-                            totalPrice,
-                            totalSalePrice,
-                            discountAmount
-                    );
+                    return CartItemResponse.from(cartItem, product);
                 })
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());

--- a/market-service/src/main/java/com/thock/back/market/app/MarketFacade.java
+++ b/market-service/src/main/java/com/thock/back/market/app/MarketFacade.java
@@ -9,6 +9,7 @@ import com.thock.back.market.in.dto.res.CartItemResponse;
 import com.thock.back.market.in.dto.res.OrderCreateResponse;
 import com.thock.back.market.in.dto.res.OrderDetailResponse;
 import com.thock.back.shared.market.domain.CancelReasonType;
+import com.thock.back.shared.product.event.ProductEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,8 @@ public class MarketFacade {
     private final MarketCancelOrderPaymentUseCase marketCancelOrderPaymentUseCase; // 주문 취소
     private final MarketCompleteRefundUseCase marketCompleteRefundUseCase; // 환불
     private final MarketConfirmOrderUseCase marketConfirmOrderUseCase; // 구매 확정
+    private final MarketSyncCartProductViewUseCase marketSyncCartProductViewUseCase;
+
     // 조회 전용
     private final CartService cartService;
     private final OrderService orderService;
@@ -105,5 +108,10 @@ public class MarketFacade {
     @Transactional
     public void confirmOrderItems(Long memberId, Long orderId, List<Long> orderItemIds) {
         marketConfirmOrderUseCase.confirmOrderItems(memberId, orderId, orderItemIds);
+    }
+
+    @Transactional
+    public void syncCartProductView(ProductEvent event) {
+        marketSyncCartProductViewUseCase.sync(event);
     }
 }

--- a/market-service/src/main/java/com/thock/back/market/app/MarketSyncCartProductViewUseCase.java
+++ b/market-service/src/main/java/com/thock/back/market/app/MarketSyncCartProductViewUseCase.java
@@ -1,0 +1,67 @@
+package com.thock.back.market.app;
+
+import com.thock.back.market.domain.CartProductView;
+import com.thock.back.market.domain.CartProductViewRepository;
+import com.thock.back.shared.product.event.ProductEvent;
+import com.thock.back.shared.product.event.ProductEventType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MarketSyncCartProductViewUseCase {
+
+    private final CartProductViewRepository cartProductViewRepository;
+
+    @Transactional
+    public void sync(ProductEvent event) {
+        CartProductView view = cartProductViewRepository.findByProductId(event.productId())
+                .orElseGet(() -> new CartProductView(
+                        event.productId(),
+                        event.sellerId(),
+                        event.name(),
+                        event.imageUrl(),
+                        event.price(),
+                        event.salePrice(),
+                        stock(event),
+                        reservedStock(event),
+                        productState(event),
+                        isDeleted(event)
+                ));
+
+        view.sync(
+                event.sellerId(),
+                event.name(),
+                event.imageUrl(),
+                event.price(),
+                event.salePrice(),
+                stock(event),
+                reservedStock(event),
+                productState(event),
+                isDeleted(event)
+        );
+
+        cartProductViewRepository.save(view);
+    }
+
+    private int stock(ProductEvent event) {
+        return event.eventType() == ProductEventType.DELETE ? 0 : nullToZero(event.stock());
+    }
+
+    private int reservedStock(ProductEvent event) {
+        return event.eventType() == ProductEventType.DELETE ? 0 : nullToZero(event.reservedStock());
+    }
+
+    private String productState(ProductEvent event) {
+        return event.productState();
+    }
+
+    private boolean isDeleted(ProductEvent event) {
+        return event.eventType() == ProductEventType.DELETE;
+    }
+
+    private int nullToZero(Integer value) {
+        return value == null ? 0 : value;
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/domain/CartProductView.java
+++ b/market-service/src/main/java/com/thock/back/market/domain/CartProductView.java
@@ -1,0 +1,70 @@
+package com.thock.back.market.domain;
+
+import com.thock.back.global.jpa.entity.BaseIdAndTime;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "market_cart_product_views")
+public class CartProductView extends BaseIdAndTime {
+
+    private Long productId;
+    private Long sellerId;
+    private String name;
+    private String imageUrl;
+    private Long price;
+    private Long salePrice;
+    private Integer stock;
+    private String productState;
+    private boolean deleted;
+
+    public CartProductView(
+            Long productId,
+            Long sellerId,
+            String name,
+            String imageUrl,
+            Long price,
+            Long salePrice,
+            Integer stock,
+            String productState,
+            boolean deleted
+    ) {
+        this.productId = productId;
+        this.sellerId = sellerId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.price = price;
+        this.salePrice = salePrice;
+        this.stock = stock;
+        this.productState = productState;
+        this.deleted = deleted;
+    }
+
+    public void sync(
+            Long sellerId,
+            String name,
+            String imageUrl,
+            Long price,
+            Long salePrice,
+            Integer stock,
+            String productState,
+            boolean deleted
+    ) {
+        this.sellerId = sellerId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.price = price;
+        this.salePrice = salePrice;
+        this.stock = stock;
+        this.productState = productState;
+        this.deleted = deleted;
+    }
+
+    public int availableStock() {
+        return stock == null ? 0 : Math.max(0, stock);
+    }
+
+    public boolean isAvailable() {
+        return !deleted && "ON_SALE".equals(productState) && availableStock() > 0;
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/domain/CartProductView.java
+++ b/market-service/src/main/java/com/thock/back/market/domain/CartProductView.java
@@ -1,13 +1,19 @@
 package com.thock.back.market.domain;
 
 import com.thock.back.global.jpa.entity.BaseIdAndTime;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "market_cart_product_views")
+@NoArgsConstructor
+@Getter
 public class CartProductView extends BaseIdAndTime {
 
+    @Column(nullable = false, unique = true)
     private Long productId;
     private Long sellerId;
     private String name;
@@ -15,6 +21,7 @@ public class CartProductView extends BaseIdAndTime {
     private Long price;
     private Long salePrice;
     private Integer stock;
+    private Integer reservedStock;
     private String productState;
     private boolean deleted;
 
@@ -26,6 +33,7 @@ public class CartProductView extends BaseIdAndTime {
             Long price,
             Long salePrice,
             Integer stock,
+            Integer reservedStock,
             String productState,
             boolean deleted
     ) {
@@ -36,6 +44,7 @@ public class CartProductView extends BaseIdAndTime {
         this.price = price;
         this.salePrice = salePrice;
         this.stock = stock;
+        this.reservedStock = reservedStock;
         this.productState = productState;
         this.deleted = deleted;
     }
@@ -47,6 +56,7 @@ public class CartProductView extends BaseIdAndTime {
             Long price,
             Long salePrice,
             Integer stock,
+            Integer reservedStock,
             String productState,
             boolean deleted
     ) {
@@ -56,12 +66,15 @@ public class CartProductView extends BaseIdAndTime {
         this.price = price;
         this.salePrice = salePrice;
         this.stock = stock;
+        this.reservedStock = reservedStock;
         this.productState = productState;
         this.deleted = deleted;
     }
 
     public int availableStock() {
-        return stock == null ? 0 : Math.max(0, stock);
+        int totalStock = stock == null ? 0 : stock;
+        int reserved = reservedStock == null ? 0 : reservedStock;
+        return Math.max(0, totalStock - reserved);
     }
 
     public boolean isAvailable() {

--- a/market-service/src/main/java/com/thock/back/market/domain/CartProductViewRepository.java
+++ b/market-service/src/main/java/com/thock/back/market/domain/CartProductViewRepository.java
@@ -1,0 +1,14 @@
+package com.thock.back.market.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface CartProductViewRepository extends JpaRepository<CartProductView, Long> {
+
+    Optional<CartProductView> findByProductId(Long productId);
+
+    List<CartProductView> findAllByProductIdIn(Collection<Long> productIds);
+}

--- a/market-service/src/main/java/com/thock/back/market/in/MarketKafkaListener.java
+++ b/market-service/src/main/java/com/thock/back/market/in/MarketKafkaListener.java
@@ -10,10 +10,13 @@ import com.thock.back.shared.member.event.MemberJoinedEvent;
 import com.thock.back.shared.member.event.MemberModifiedEvent;
 import com.thock.back.shared.payment.event.PaymentCompletedEvent;
 import com.thock.back.shared.payment.event.PaymentRefundCompletedEvent;
+import com.thock.back.shared.product.event.ProductEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +33,7 @@ public class MarketKafkaListener {
 
     @KafkaListener(topics = KafkaTopics.MEMBER_JOINED, groupId = "market-service")
     @Transactional
-    public void handle(MemberJoinedEvent event){
+    public void handle(MemberJoinedEvent event) {
         inboundMetrics.recordReceived(KafkaTopics.MEMBER_JOINED);
         if (!shouldProcess(KafkaTopics.MEMBER_JOINED, keyResolver.memberJoined(event))) {
             inboundMetrics.recordDuplicate(KafkaTopics.MEMBER_JOINED);
@@ -49,7 +52,7 @@ public class MarketKafkaListener {
 
     @KafkaListener(topics = KafkaTopics.MEMBER_MODIFIED, groupId = "market-service")
     @Transactional
-    public void handle(MemberModifiedEvent event){
+    public void handle(MemberModifiedEvent event) {
         inboundMetrics.recordReceived(KafkaTopics.MEMBER_MODIFIED);
         if (!shouldProcess(KafkaTopics.MEMBER_MODIFIED, keyResolver.memberModified(event))) {
             inboundMetrics.recordDuplicate(KafkaTopics.MEMBER_MODIFIED);
@@ -69,7 +72,7 @@ public class MarketKafkaListener {
     // 결제 완료가 되었을 때 payment 모듈에서 이벤트를 날리면 이벤트를 받아서 Order의 상태를 변경함
     @KafkaListener(topics = KafkaTopics.PAYMENT_COMPLETED, groupId = "market-service")
     @Transactional
-    public void handle(PaymentCompletedEvent event){
+    public void handle(PaymentCompletedEvent event) {
         inboundMetrics.recordReceived(KafkaTopics.PAYMENT_COMPLETED);
         if (!shouldProcess(KafkaTopics.PAYMENT_COMPLETED, keyResolver.paymentCompleted(event))) {
             inboundMetrics.recordDuplicate(KafkaTopics.PAYMENT_COMPLETED);
@@ -88,7 +91,7 @@ public class MarketKafkaListener {
 
     @KafkaListener(topics = KafkaTopics.PAYMENT_REFUND_COMPLETED, groupId = "market-service")
     @Transactional
-    public void handle(PaymentRefundCompletedEvent event){
+    public void handle(PaymentRefundCompletedEvent event) {
         inboundMetrics.recordReceived(KafkaTopics.PAYMENT_REFUND_COMPLETED);
         if (!shouldProcess(
                 KafkaTopics.PAYMENT_REFUND_COMPLETED,
@@ -105,6 +108,37 @@ public class MarketKafkaListener {
             inboundMetrics.recordProcessed(KafkaTopics.PAYMENT_REFUND_COMPLETED);
         } catch (Exception e) {
             inboundMetrics.recordFailed(KafkaTopics.PAYMENT_REFUND_COMPLETED);
+            throw e;
+        }
+    }
+
+    @KafkaListener(topics = KafkaTopics.PRODUCT_CHANGED, groupId = "market-service")
+    @Transactional
+    public void handle(
+            ProductEvent event,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset
+    ) {
+        inboundMetrics.recordReceived(KafkaTopics.PRODUCT_CHANGED);
+
+        String idempotencyKey = String.join(":",
+                "product-changed",
+                String.valueOf(partition),
+                String.valueOf(offset)
+        );
+
+        if (!shouldProcess(KafkaTopics.PRODUCT_CHANGED, idempotencyKey)) {
+            inboundMetrics.recordDuplicate(KafkaTopics.PRODUCT_CHANGED);
+            return;
+        }
+
+        try {
+            log.info("Received ProductEvent via Kafka: productId={}, eventType={}, partition={}, offset={}",
+                    event.productId(), event.eventType(), partition, offset);
+            marketFacade.syncCartProductView(event);
+            inboundMetrics.recordProcessed(KafkaTopics.PRODUCT_CHANGED);
+        } catch (Exception e) {
+            inboundMetrics.recordFailed(KafkaTopics.PRODUCT_CHANGED);
             throw e;
         }
     }

--- a/market-service/src/main/java/com/thock/back/market/in/dto/res/CartItemResponse.java
+++ b/market-service/src/main/java/com/thock/back/market/in/dto/res/CartItemResponse.java
@@ -1,6 +1,7 @@
 package com.thock.back.market.in.dto.res;
 
 import com.thock.back.market.domain.CartItem;
+import com.thock.back.market.domain.CartProductView;
 import com.thock.back.market.out.api.dto.ProductInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -59,5 +60,25 @@ public record CartItemResponse (
                 totalSalePrice,
                 totalDiscountAmount
                 );
+    }
+
+    public static CartItemResponse from(CartItem item, CartProductView product) {
+        Long totalPrice = item.getQuantity() * product.getPrice();
+        Long totalSalePrice = item.getQuantity() * product.getSalePrice();
+        Long totalDiscountAmount = totalPrice - totalSalePrice;
+
+        return new CartItemResponse(
+                item.getId(),
+                item.getQuantity(),
+                product.getProductId(),
+                product.getName(),
+                product.getImageUrl(),
+                product.getPrice(),
+                product.getSalePrice(),
+                product.availableStock(),
+                totalPrice,
+                totalSalePrice,
+                totalDiscountAmount
+        );
     }
 }

--- a/market-service/src/main/java/com/thock/back/market/in/idempotency/MarketInboundEventIdempotencyKeyResolver.java
+++ b/market-service/src/main/java/com/thock/back/market/in/idempotency/MarketInboundEventIdempotencyKeyResolver.java
@@ -4,6 +4,7 @@ import com.thock.back.shared.member.event.MemberJoinedEvent;
 import com.thock.back.shared.member.event.MemberModifiedEvent;
 import com.thock.back.shared.payment.event.PaymentCompletedEvent;
 import com.thock.back.shared.payment.event.PaymentRefundCompletedEvent;
+import com.thock.back.shared.product.event.ProductEvent;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -37,6 +38,22 @@ public class MarketInboundEventIdempotencyKeyResolver {
                 "payment-refund-completed",
                 event.dto().orderId(),
                 String.valueOf(event.dto().amount())
+        );
+    }
+
+    public String productChanged(ProductEvent event) {
+        return String.join(":",
+                "product-changed",
+                String.valueOf(event.productId()),
+                String.valueOf(event.eventType()),
+                String.valueOf(event.name()),
+                String.valueOf(event.price()),
+                String.valueOf(event.salePrice()),
+                String.valueOf(event.stock()),
+                String.valueOf(event.reservedStock()),
+                String.valueOf(event.productState()),
+                String.valueOf(event.imageUrl()),
+                String.valueOf(event.description())
         );
     }
 }

--- a/market-service/src/test/java/com/thock/back/market/app/CartServiceTest.java
+++ b/market-service/src/test/java/com/thock/back/market/app/CartServiceTest.java
@@ -3,8 +3,11 @@ package com.thock.back.market.app;
 import com.thock.back.global.exception.CustomException;
 import com.thock.back.global.exception.ErrorCode;
 import com.thock.back.market.domain.Cart;
+import com.thock.back.market.domain.CartProductView;
+import com.thock.back.market.domain.CartProductViewRepository;
 import com.thock.back.market.domain.MarketMember;
 import com.thock.back.market.in.dto.req.CartItemAddRequest;
+import com.thock.back.market.in.dto.res.CartItemListResponse;
 import com.thock.back.market.out.api.dto.ProductInfo;
 import com.thock.back.shared.member.domain.MemberRole;
 import com.thock.back.shared.member.domain.MemberState;
@@ -16,10 +19,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class CartServiceTest {
@@ -29,6 +36,50 @@ class CartServiceTest {
 
     @Mock
     private MarketSupport marketSupport;
+    @Mock
+    private CartProductViewRepository cartProductViewRepository;
+
+    @Test
+    @DisplayName("장바구니 조회 시 CQRS projection에서 상품 정보를 읽는다")
+    void getCartItems_readsFromCartProductView() {
+        Long memberId = 1L;
+        MarketMember buyer = new MarketMember(
+                "buyer@test.com",
+                "buyer",
+                MemberRole.USER,
+                MemberState.ACTIVE,
+                memberId,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+        Cart cart = new Cart(buyer);
+        cart.addItem(100L, 2);
+
+        CartProductView productView = new CartProductView(
+                100L,
+                2L,
+                "keyboard",
+                "image",
+                10000L,
+                9000L,
+                10,
+                3,
+                "ON_SALE",
+                false
+        );
+
+        given(marketSupport.findMemberById(memberId)).willReturn(Optional.of(buyer));
+        given(marketSupport.findCartByBuyer(buyer)).willReturn(Optional.of(cart));
+        given(cartProductViewRepository.findAllByProductIdIn(List.of(100L))).willReturn(List.of(productView));
+
+        CartItemListResponse response = cartService.getCartItems(memberId);
+
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.items().get(0).productId()).isEqualTo(100L);
+        assertThat(response.items().get(0).productName()).isEqualTo("keyboard");
+        assertThat(response.items().get(0).stock()).isEqualTo(7);
+        verify(marketSupport, never()).getProducts(List.of(100L));
+    }
 
     @Test
     @DisplayName("장바구니 추가 시 예약 재고를 제외한 주문 가능 재고를 기준으로 검증한다")

--- a/product-service/src/main/java/com/thock/back/product/app/ProductCreateService.java
+++ b/product-service/src/main/java/com/thock/back/product/app/ProductCreateService.java
@@ -40,6 +40,14 @@ public class ProductCreateService {
         productEventPublisher.publish(ProductEvent.builder()
                 .productId(saved.getId())
                 .sellerId(saved.getSellerId())
+                .name(saved.getName())
+                .price(saved.getPrice())
+                .salePrice(saved.getSalePrice())
+                .description(saved.getDescription())
+                .stock(saved.getStock())
+                .reservedStock(saved.getReservedStock())
+                .imageUrl(saved.getImageUrl())
+                .productState(saved.getState().name())
                 .eventType(ProductEventType.CREATE)
                 .build());
 

--- a/product-service/src/main/java/com/thock/back/product/app/ProductManageService.java
+++ b/product-service/src/main/java/com/thock/back/product/app/ProductManageService.java
@@ -46,7 +46,9 @@ public class ProductManageService {
                 .name(product.getName())
                 .price(product.getPrice())
                 .salePrice(product.getSalePrice())
+                .description(product.getDescription())
                 .stock(product.getStock())
+                .reservedStock(product.getReservedStock())
                 .imageUrl(product.getImageUrl())
                 .productState(product.getState().name())
                 .eventType(ProductEventType.UPDATE)
@@ -64,11 +66,27 @@ public class ProductManageService {
         Long deletedId = product.getId();
         Long sellerId = product.getSellerId();
 
+        String name = product.getName();
+        Long price = product.getPrice();
+        Long salePrice = product.getSalePrice();
+        String description = product.getDescription();
+        Integer stock = product.getStock();
+        Integer reservedStock = product.getReservedStock();
+        String imageUrl = product.getImageUrl();
+
         productRepository.delete(product);
 
         productEventPublisher.publish(ProductEvent.builder()
                 .productId(deletedId)
                 .sellerId(sellerId)
+                .name(name)
+                .price(price)
+                .salePrice(salePrice)
+                .description(description)
+                .stock(stock)
+                .reservedStock(reservedStock)
+                .imageUrl(imageUrl)
+                .productState("DELETED")
                 .eventType(ProductEventType.DELETE)
                 .build());
     }

--- a/product-service/src/main/java/com/thock/back/product/app/ProductStockService.java
+++ b/product-service/src/main/java/com/thock/back/product/app/ProductStockService.java
@@ -3,10 +3,13 @@ package com.thock.back.product.app;
 import com.thock.back.global.exception.CustomException;
 import com.thock.back.global.exception.ErrorCode;
 import com.thock.back.product.domain.entity.Product;
+import com.thock.back.product.messaging.publisher.ProductEventPublisher;
 import com.thock.back.product.out.ProductRepository;
 import com.thock.back.shared.market.domain.StockEventType;
 import com.thock.back.shared.market.dto.StockOrderItemDto;
 import com.thock.back.shared.market.event.MarketOrderStockChangedEvent;
+import com.thock.back.shared.product.event.ProductEvent;
+import com.thock.back.shared.product.event.ProductEventType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +23,8 @@ import java.util.stream.Collectors;
 public class ProductStockService {
 
     private final ProductRepository productRepository;
+
+    private final ProductEventPublisher productEventPublisher;
 
     // 주문의 재고 변경 이벤트 처리 (예약, 해제, 커밋)
     @Transactional
@@ -66,8 +71,22 @@ public class ProductStockService {
             } else {
                 throw new CustomException(ErrorCode.INVALID_REQUEST);
             }
-
         }
 
+        for (Product product : products) {
+            productEventPublisher.publish(ProductEvent.builder()
+                    .productId(product.getId())
+                    .sellerId(product.getSellerId())
+                    .name(product.getName())
+                    .price(product.getPrice())
+                    .salePrice(product.getSalePrice())
+                    .description(product.getDescription())
+                    .stock(product.getStock())
+                    .reservedStock(product.getReservedStock())
+                    .imageUrl(product.getImageUrl())
+                    .productState(product.getState().name())
+                    .eventType(ProductEventType.UPDATE)
+                    .build());
+        }
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #24 

## 변경 내용
- 상품 정보 변경 이벤트 리스너 구현
- 주문 모듈 내 상품 읽기 전용 테이블 생성

## 확인 내용
- 읽기 테이블 작동 여부 확인 통합테스트 완료
- k6 부하 테스트로 성능 개선 확인 완료
