### PR TITLE
[FEAT] 상품 키워드 검색 API 동적 쿼리 적용

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -44,6 +44,11 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -21,6 +21,11 @@ repositories {
 dependencies {
     implementation project(':common')
 
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
     // .env 파일 로드
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
@@ -45,6 +50,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // JWT

--- a/product-service/src/main/java/com/thock/back/product/app/ProductQueryService.java
+++ b/product-service/src/main/java/com/thock/back/product/app/ProductQueryService.java
@@ -5,7 +5,8 @@ import com.thock.back.global.exception.ErrorCode;
 import com.thock.back.product.domain.Category;
 import com.thock.back.product.domain.entity.Product;
 import com.thock.back.product.in.dto.ProductDetailResponse;
-import com.thock.back.product.in.dto.ProductListResponse;
+import com.thock.back.product.in.dto.ProductSearchResponse;
+import com.thock.back.product.in.dto.ProductSearchRequest;
 import com.thock.back.product.in.dto.internal.ProductInternalResponse;
 import com.thock.back.product.out.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,24 +23,15 @@ import java.util.List;
 public class ProductQueryService {
     private final ProductRepository productRepository;
 
-    public Page<ProductListResponse> searchProductsByCategory(Category category, Pageable pageable) {
+    public Page<ProductSearchResponse> searchProductsByCategory(Category category, Pageable pageable) {
         return productRepository.findByCategory(category, pageable)
-                .map(ProductListResponse::new);
+                .map(ProductSearchResponse::new);
     }
 
     public ProductDetailResponse getProductById(Long id) {
         Product product = productRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
         return new ProductDetailResponse(product);
-    }
-
-    public List<ProductListResponse> searchProductsByKeyword(String keyword) {
-        if (keyword == null || keyword.isBlank()) {
-            return List.of();
-        }
-        return productRepository.findByNameContaining(keyword).stream()
-                .map(ProductListResponse::new)
-                .toList();
     }
 
     public List<ProductInternalResponse> getProductsByIds(List<Long> productIds) {
@@ -51,8 +43,12 @@ public class ProductQueryService {
                 .toList();
     }
 
-    public Page<ProductListResponse> getMyProducts(Long sellerId, Pageable pageable) {
+    public Page<ProductSearchResponse> searchProducts(ProductSearchRequest condition, Pageable pageable) {
+        return productRepository.search(condition, pageable);
+    }
+
+    public Page<ProductSearchResponse> getMyProducts(Long sellerId, Pageable pageable) {
         return productRepository.findBySellerId(sellerId, pageable)
-                .map(ProductListResponse::new);
+                .map(ProductSearchResponse::new);
     }
 }

--- a/product-service/src/main/java/com/thock/back/product/in/ProductController.java
+++ b/product-service/src/main/java/com/thock/back/product/in/ProductController.java
@@ -6,13 +6,9 @@ import com.thock.back.product.app.ProductCreateService;
 import com.thock.back.product.app.ProductManageService;
 import com.thock.back.product.app.ProductQueryService;
 import com.thock.back.product.domain.Category;
-import com.thock.back.product.in.dto.ProductCreateRequest;
-import com.thock.back.product.in.dto.ProductDetailResponse;
-import com.thock.back.product.in.dto.ProductListResponse;
-import com.thock.back.product.in.dto.ProductUpdateRequest;
+import com.thock.back.product.in.dto.*;
 import com.thock.back.product.in.dto.internal.ProductInternalResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -63,7 +59,7 @@ public class ProductController {
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
     @GetMapping
-    public ResponseEntity<Page<ProductListResponse>> getProductList(
+    public ResponseEntity<Page<ProductSearchResponse>> getProductList(
             @RequestParam Category category,
             @ParameterObject @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
@@ -116,15 +112,16 @@ public class ProductController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "상품 검색", description = "키워드로 상품을 검색합니다.")
+    @Operation(summary = "상품 검색", description = "조건에 따라 상품을 검색합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "검색 성공")
     })
     @GetMapping("/search")
-    public ResponseEntity<List<ProductListResponse>> searchProducts(
-            @Parameter(description = "검색어") @RequestParam String keyword
+    public ResponseEntity<Page<ProductSearchResponse>> searchProducts(
+            @ParameterObject ProductSearchRequest condition,
+            @ParameterObject @PageableDefault(size = 10) Pageable pageable
     ) {
-        return ResponseEntity.ok(productQueryService.searchProductsByKeyword(keyword));
+        return ResponseEntity.ok(productQueryService.searchProducts(condition, pageable));
     }
 
     @Operation(
@@ -152,7 +149,7 @@ public class ProductController {
             @ApiResponse(responseCode = "403", description = "권한 없음")
     })
     @GetMapping("/me")
-    public ResponseEntity<Page<ProductListResponse>> getMyProducts(
+    public ResponseEntity<Page<ProductSearchResponse>> getMyProducts(
             @AuthUser AuthenticatedUser user,
             @ParameterObject @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {

--- a/product-service/src/main/java/com/thock/back/product/in/dto/ProductSearchRequest.java
+++ b/product-service/src/main/java/com/thock/back/product/in/dto/ProductSearchRequest.java
@@ -1,0 +1,16 @@
+package com.thock.back.product.in.dto;
+
+import com.thock.back.product.domain.Category;
+import com.thock.back.product.domain.ProductState;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 검색 조건")
+public record ProductSearchRequest(
+        @Schema(description = "검색어") String keyword,
+        @Schema(description = "카테고리") Category category,
+        @Schema(description = "최소 가격") Long minPrice,
+        @Schema(description = "최대 가격") Long maxPrice,
+        @Schema(description = "판매 상태") ProductState state,
+        @Schema(description = "정렬 기준") ProductSearchSortType sort
+) {
+}

--- a/product-service/src/main/java/com/thock/back/product/in/dto/ProductSearchResponse.java
+++ b/product-service/src/main/java/com/thock/back/product/in/dto/ProductSearchResponse.java
@@ -2,14 +2,14 @@ package com.thock.back.product.in.dto;
 
 import com.thock.back.product.domain.entity.Product;
 
-public record ProductListResponse (
+public record ProductSearchResponse(
         Long id,
         String name,
         String imageUrl,
         Long price,
-        String nickname
+        String seller
 ) {
-    public ProductListResponse(Product product) {
+    public ProductSearchResponse(Product product) {
         this(
                 product.getId(),
                 product.getName(),

--- a/product-service/src/main/java/com/thock/back/product/in/dto/ProductSearchSortType.java
+++ b/product-service/src/main/java/com/thock/back/product/in/dto/ProductSearchSortType.java
@@ -1,0 +1,7 @@
+package com.thock.back.product.in.dto;
+
+public enum ProductSearchSortType {
+    LATEST,
+    PRICE_ASC,
+    PRICE_DESC
+}

--- a/product-service/src/main/java/com/thock/back/product/out/ProductRepository.java
+++ b/product-service/src/main/java/com/thock/back/product/out/ProductRepository.java
@@ -14,10 +14,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProductRepository extends JpaRepository<Product, Long> {
-
-    // 상품명으로 검색 (부분 일치)
-    List<Product> findByNameContaining(String keyword);
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
 
     // 카테고리로 검색 (페이징)
     Page<Product> findByCategory(Category category, Pageable pageable);

--- a/product-service/src/main/java/com/thock/back/product/out/ProductRepositoryCustom.java
+++ b/product-service/src/main/java/com/thock/back/product/out/ProductRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.thock.back.product.out;
+
+import com.thock.back.product.in.dto.ProductSearchResponse;
+import com.thock.back.product.in.dto.ProductSearchRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProductRepositoryCustom {
+    Page<ProductSearchResponse> search(ProductSearchRequest condition, Pageable pageable);
+}

--- a/product-service/src/main/java/com/thock/back/product/out/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/thock/back/product/out/ProductRepositoryImpl.java
@@ -1,0 +1,87 @@
+package com.thock.back.product.out;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.thock.back.product.domain.entity.QProduct;
+import com.thock.back.product.in.dto.ProductSearchResponse;
+import com.thock.back.product.in.dto.ProductSearchRequest;
+import com.thock.back.product.in.dto.ProductSearchSortType;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public ProductRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<ProductSearchResponse> search(ProductSearchRequest condition, Pageable pageable) {
+        QProduct product = QProduct.product;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (condition != null) {
+            if (condition.keyword() != null && !condition.keyword().isBlank()) {
+                builder.and(product.name.containsIgnoreCase(condition.keyword()));
+            }
+            if (condition.category() != null) {
+                builder.and(product.category.eq(condition.category()));
+            }
+            if (condition.minPrice() != null) {
+                builder.and(product.price.goe(condition.minPrice()));
+            }
+            if (condition.maxPrice() != null) {
+                builder.and(product.price.loe(condition.maxPrice()));
+            }
+            if (condition.state() != null) {
+                builder.and(product.state.eq(condition.state()));
+            }
+        }
+
+        List<ProductSearchResponse> content = queryFactory
+                .select(Projections.constructor(
+                        ProductSearchResponse.class,
+                        product.id,
+                        product.name,
+                        product.imageUrl,
+                        product.price,
+                        Expressions.stringTemplate("concat('판매자 ', {0})", product.sellerId.stringValue())
+                ))
+                .from(product)
+                .where(builder)
+                .orderBy(getOrderSpecifier(product, condition))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(product.count())
+                .from(product)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(QProduct product, ProductSearchRequest condition) {
+        ProductSearchSortType sortType =
+                condition == null || condition.sort() == null
+                        ? ProductSearchSortType.LATEST
+                        : condition.sort();
+
+        return switch (sortType) {
+            case PRICE_ASC -> product.price.asc();
+            case PRICE_DESC -> product.price.desc();
+            case LATEST -> product.id.desc();
+        };
+    }
+}

--- a/product-service/src/main/resources/db/migration/V7__add_product_search_indexes.sql
+++ b/product-service/src/main/resources/db/migration/V7__add_product_search_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_products_category_state_price_id
+    ON products (category, state, price, id);

--- a/product-service/src/test/java/com/thock/back/product/app/ProductQueryServiceIntegrationTest.java
+++ b/product-service/src/test/java/com/thock/back/product/app/ProductQueryServiceIntegrationTest.java
@@ -1,0 +1,110 @@
+package com.thock.back.product.app;
+
+import com.thock.back.product.ProductServiceApplication;
+import com.thock.back.product.domain.Category;
+import com.thock.back.product.domain.entity.Product;
+import com.thock.back.product.in.dto.ProductSearchRequest;
+import com.thock.back.product.in.dto.ProductSearchResponse;
+import com.thock.back.product.in.dto.ProductSearchSortType;
+import com.thock.back.product.out.ProductRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = ProductServiceApplication.class, properties = {
+        "spring.datasource.url=jdbc:h2:mem:product-query-test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.flyway.enabled=false"
+})
+@ActiveProfiles("test")
+@Transactional
+class ProductQueryServiceIntegrationTest {
+
+    @Autowired
+    private ProductQueryService productQueryService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @AfterEach
+    void tearDown() {
+        productRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("키워드와 가격 범위 조건으로 상품을 검색한다")
+    void searchProducts_withKeywordAndPriceRange() {
+        productRepository.save(createProduct("기계식 키보드", 15_000L));
+        productRepository.save(createProduct("무선 키보드", 30_000L));
+        productRepository.save(createProduct("장패드", 8_000L));
+
+        ProductSearchRequest condition = new ProductSearchRequest(
+                "키보드",
+                null,
+                10_000L,
+                20_000L,
+                null,
+                ProductSearchSortType.LATEST
+        );
+
+        Page<ProductSearchResponse> result =
+                productQueryService.searchProducts(condition, PageRequest.of(0, 10));
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent())
+                .extracting(ProductSearchResponse::name)
+                .containsExactly("기계식 키보드");
+        assertThat(result.getContent().get(0).seller()).isEqualTo("판매자 1");
+    }
+
+    @Test
+    @DisplayName("가격 오름차순으로 정렬하고 페이지네이션한다")
+    void searchProducts_withPriceAscSortAndPaging() {
+        productRepository.save(createProduct("키보드 A", 30_000L));
+        productRepository.save(createProduct("키보드 B", 10_000L));
+        productRepository.save(createProduct("키보드 C", 20_000L));
+
+        ProductSearchRequest condition = new ProductSearchRequest(
+                "키보드",
+                null,
+                null,
+                null,
+                null,
+                ProductSearchSortType.PRICE_ASC
+        );
+
+        Page<ProductSearchResponse> result =
+                productQueryService.searchProducts(condition, PageRequest.of(0, 2));
+
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent())
+                .extracting(ProductSearchResponse::name)
+                .containsExactly("키보드 B", "키보드 C");
+    }
+
+    private Product createProduct(String name, Long price) {
+        return Product.builder()
+                .sellerId(1L)
+                .category(Category.KEYBOARD)
+                .name(name)
+                .description(name + " 설명")
+                .price(price)
+                .salePrice(price)
+                .stock(100)
+                .imageUrl("https://example.com/product.png")
+                .detail(null)
+                .build();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #31 

## 변경 내용
- 상품 키워드 검색 쿼리에 Querydsl을 적용하여 동적 쿼리 구현

## 확인 내용
- Swagger API 스모크 테스트 및 통합 테스트 통과
