### PR TITLE
[FEAT] 상품 단건 조회 및 다건 조회 캐시 적용

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,9 @@ services:
       MYSQL_USER: thock_product_db_user
       MYSQL_PASSWORD: ${PRODUCT_DB_PASSWORD}
       KAFKA_BOOTSTRAP_SERVERS: redpanda:29092
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      PRODUCT_CACHE_ENABLED: true
       PRODUCT_EVENT_PUBLISH_MODE: ${PRODUCT_EVENT_PUBLISH_MODE:-outbox}
       PRODUCT_KAFKA_LISTENER_CONCURRENCY: ${PRODUCT_KAFKA_LISTENER_CONCURRENCY:-1}
       PRODUCT_INBOX_ENABLED: ${PRODUCT_INBOX_ENABLED:-true}
@@ -117,6 +120,8 @@ services:
       mysql:
         condition: service_healthy
       redpanda:
+        condition: service_started
+      redis:
         condition: service_started
     networks:
       - internal
@@ -235,6 +240,15 @@ services:
       - internal
     volumes:
       - ./logs/settlement:/app/logs
+    restart: unless-stopped
+  # ==================== Redis ====================
+  redis:
+    image: redis:7.4-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+    networks:
+      - internal
     restart: unless-stopped
 
   # ==================== Kafka ====================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,8 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: redpanda:29092
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      PRODUCT_CACHE_ENABLED: true
+      PRODUCT_CACHE_ENABLED: ${PRODUCT_CACHE_ENABLED:-true}
+      PRODUCT_CACHE_TTL_SECONDS: ${PRODUCT_CACHE_TTL_SECONDS:-600}
       PRODUCT_EVENT_PUBLISH_MODE: ${PRODUCT_EVENT_PUBLISH_MODE:-outbox}
       PRODUCT_KAFKA_LISTENER_CONCURRENCY: ${PRODUCT_KAFKA_LISTENER_CONCURRENCY:-1}
       PRODUCT_INBOX_ENABLED: ${PRODUCT_INBOX_ENABLED:-true}
@@ -398,6 +399,16 @@ services:
       PRICE: ${K6_PRICE:-1000}
       SALE_PRICE: ${K6_SALE_PRICE:-0}
       STOCK: ${K6_STOCK:-5}
+      TARGET: ${K6_TARGET:-internal}
+      WARM_CACHE: ${K6_WARM_CACHE:-true}
+      PRODUCT_IDS: ${K6_PRODUCT_IDS:-1,2,3}
+      PRODUCT_BATCH_SIZE: ${K6_PRODUCT_BATCH_SIZE:-3}
+      DETAIL_BASE_URL: ${K6_DETAIL_BASE_URL:-http://product-service:8082}
+      INTERNAL_BASE_URL: ${K6_INTERNAL_BASE_URL:-http://product-service:8082}
+      INTERNAL_AUTH_SECRET: ${SECURITY_SERVICE_INTERNAL_SECRET:-}
+      EXECUTOR: ${K6_EXECUTOR:-iterations}
+      ITERATIONS: ${K6_ITERATIONS:-3000}
+      VUS: ${K6_VUS:-50}
       BANK_CODE: ${K6_BANK_CODE:-088}
       ACCOUNT_NUMBER: ${K6_ACCOUNT_NUMBER:-1234567890}
       ACCOUNT_HOLDER: ${K6_ACCOUNT_HOLDER:-k6-seller}
@@ -415,6 +426,8 @@ services:
       member-service:
         condition: service_started
       product-service:
+        condition: service_started
+      redis:
         condition: service_started
     restart: "no"
 

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -26,6 +26,37 @@ Run the full experiment wrapper with Kafka topic counting and DB comparison.
 bash loadtest/run-product-create-experiment.sh
 ```
 
+Run the product Redis cache Before/After experiment.
+
+```bash
+TARGET=internal PRODUCT_IDS=1,2,3 K6_ITERATIONS=3000 K6_VUS=50 \
+bash loadtest/run-product-cache-experiment.sh
+```
+
+This wrapper runs the same `k6` load twice:
+
+- `cache-off`: restarts `product-service` with `PRODUCT_CACHE_ENABLED=false`
+- `cache-on`: restarts `product-service` with `PRODUCT_CACHE_ENABLED=true`
+- Redis is flushed before each phase with `redis-cli FLUSHDB`
+- The default executor is `shared-iterations`, so the cache-off/on business request count is fixed
+- Summary files are written under `loadtest/results/`
+
+Use `product_detail_reads_total` or `product_internal_list_reads_total` as the business request count.
+`http_reqs_count` includes setup/warm-up requests.
+
+Supported cache targets:
+
+- `TARGET=detail`: `GET /api/v1/products/{id}` directly to `product-service`
+- `TARGET=internal`: `POST /api/v1/products/internal/list` directly to `product-service`
+- `TARGET=mixed`: alternates detail and internal list reads
+
+If you want to measure the external route including Gateway overhead, override:
+
+```bash
+TARGET=detail K6_DETAIL_BASE_URL=http://api-gateway:8080 \
+bash loadtest/run-product-cache-experiment.sh
+```
+
 Reset the product experiment state cleanly before each run.
 
 ```bash
@@ -43,6 +74,14 @@ bash loadtest/reset-product-experiment.sh
 - `PRICE=1000`
 - `SALE_PRICE=0`
 - `STOCK=5`
+- `TARGET=internal`
+- `PRODUCT_IDS=1,2,3`
+- `PRODUCT_BATCH_SIZE=3`
+- `WARM_CACHE=true`
+- `K6_EXECUTOR=iterations`
+- `K6_ITERATIONS=3000`
+- `K6_VUS=50`
+- `K6_DETAIL_BASE_URL=http://product-service:8082`
 - `SUMMARY_PATH=/results/direct-baseline-summary.json`
 - `RUN_ID=1742000000`
 

--- a/loadtest/product-cache-read.js
+++ b/loadtest/product-cache-read.js
@@ -1,0 +1,350 @@
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { check, fail, sleep } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+
+const productDetailReads = new Counter('product_detail_reads_total');
+const productDetailFailures = new Counter('product_detail_read_failures_total');
+const productInternalReads = new Counter('product_internal_list_reads_total');
+const productInternalFailures = new Counter('product_internal_list_failures_total');
+const productDetailDuration = new Trend('product_detail_duration', true);
+const productInternalListDuration = new Trend('product_internal_list_duration', true);
+
+const experimentRunId = __ENV.RUN_ID || `${Date.now()}`;
+const target = (__ENV.TARGET || 'internal').toLowerCase();
+const supportedTargets = ['detail', 'internal', 'mixed'];
+const rate = parsePositiveInteger(__ENV.RATE, 50);
+const preAllocatedVUs = parsePositiveInteger(__ENV.PRE_ALLOCATED_VUS, 50);
+const maxVUs = parsePositiveInteger(__ENV.MAX_VUS, 100);
+const executor = (__ENV.EXECUTOR || 'iterations').toLowerCase();
+const iterations = parsePositiveInteger(__ENV.ITERATIONS, 3000);
+const vus = parsePositiveInteger(__ENV.VUS, 50);
+const sleepBetween = parseNonNegativeNumber(__ENV.SLEEP_BETWEEN, 0);
+const warmCache = (__ENV.WARM_CACHE || 'true').toLowerCase() === 'true';
+const productIds = parseProductIds(__ENV.PRODUCT_IDS || '1,2,3');
+const productBatchSize = parsePositiveInteger(__ENV.PRODUCT_BATCH_SIZE, productIds.length);
+
+export const options = {
+  scenarios: {
+    product_cache_read_load: buildScenario(),
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    http_req_duration: ['p(95)<2000'],
+    checks: ['rate>0.99'],
+  },
+};
+
+export function setup() {
+  if (executor !== 'iterations' && executor !== 'rate') {
+    fail('EXECUTOR must be either iterations or rate.');
+  }
+  if (!supportedTargets.includes(target)) {
+    fail(`TARGET must be one of ${supportedTargets.join(', ')}.`);
+  }
+  if (productIds.length === 0) {
+    fail('PRODUCT_IDS must contain at least one valid product id.');
+  }
+
+  const baseUrl = (__ENV.BASE_URL || 'http://api-gateway:8080').replace(/\/$/, '');
+  const detailBaseUrl = (__ENV.DETAIL_BASE_URL || baseUrl).replace(/\/$/, '');
+  const internalBaseUrl = (__ENV.INTERNAL_BASE_URL || 'http://product-service:8082').replace(/\/$/, '');
+  const internalAuthSecret =
+    __ENV.INTERNAL_AUTH_SECRET || __ENV.SECURITY_SERVICE_INTERNAL_SECRET || '';
+
+  if (usesInternalEndpoint() && !internalAuthSecret) {
+    fail('INTERNAL_AUTH_SECRET or SECURITY_SERVICE_INTERNAL_SECRET is required for internal product API.');
+  }
+
+  if (warmCache && target === 'detail') {
+    warmDetailCache(detailBaseUrl, productIds);
+  } else if (warmCache && target === 'internal') {
+    warmInternalCache(internalBaseUrl, internalAuthSecret, productIds);
+  } else if (warmCache) {
+    warmDetailCache(detailBaseUrl, productIds);
+    warmInternalCache(internalBaseUrl, internalAuthSecret, productIds);
+  }
+
+  return {
+    baseUrl,
+    detailBaseUrl,
+    internalBaseUrl,
+    internalAuthSecret,
+  };
+}
+
+export default function (data) {
+  const iteration = exec.scenario.iterationInTest;
+
+  if (target === 'detail') {
+    readProductDetail(data.detailBaseUrl, productIds[iteration % productIds.length]);
+  } else if (target === 'internal') {
+    readInternalProductList(data.internalBaseUrl, data.internalAuthSecret, pickBatch(productIds, iteration));
+  } else if (iteration % 2 === 0) {
+    readProductDetail(data.detailBaseUrl, productIds[iteration % productIds.length]);
+  } else {
+    readInternalProductList(data.internalBaseUrl, data.internalAuthSecret, pickBatch(productIds, iteration));
+  }
+
+  if (sleepBetween > 0) {
+    sleep(sleepBetween);
+  }
+}
+
+export function handleSummary(data) {
+  const summaryPath =
+    __ENV.SUMMARY_PATH || `/results/product-cache-read-${target}-${experimentRunId}.json`;
+
+  return {
+    stdout: [
+      '',
+      `experiment=${__ENV.EXPERIMENT_NAME || 'product-cache-read-load'}`,
+      `run_id=${experimentRunId}`,
+      `target=${target}`,
+      `executor=${executor}`,
+      `warm_cache=${warmCache}`,
+      `product_ids=${productIds.join(',')}`,
+      `product_batch_size=${productBatchSize}`,
+      `iterations=${executor === 'iterations' ? iterations : 'n/a'}`,
+      `vus=${executor === 'iterations' ? vus : 'n/a'}`,
+      `rate=${executor === 'rate' ? rate : 'n/a'}`,
+      `duration=${executor === 'rate' ? (__ENV.DURATION || '1m') : 'n/a'}`,
+      `http_req_failed_rate=${formatMetricValue(data.metrics.http_req_failed, 'rate')}`,
+      `http_req_duration_avg=${formatMetricValue(data.metrics.http_req_duration, 'avg')}ms`,
+      `http_req_duration_p95=${formatMetricValue(data.metrics.http_req_duration, 'p(95)')}ms`,
+      `http_reqs_count=${formatMetricValue(data.metrics.http_reqs, 'count')}`,
+      `http_reqs_rate=${formatMetricValue(data.metrics.http_reqs, 'rate')}`,
+      `product_detail_reads_total=${formatMetricValue(data.metrics.product_detail_reads_total, 'count')}`,
+      `product_detail_read_failures_total=${formatMetricValue(data.metrics.product_detail_read_failures_total, 'count')}`,
+      `product_detail_duration_avg=${formatMetricValue(data.metrics.product_detail_duration, 'avg')}ms`,
+      `product_detail_duration_p95=${formatMetricValue(data.metrics.product_detail_duration, 'p(95)')}ms`,
+      `product_internal_list_reads_total=${formatMetricValue(data.metrics.product_internal_list_reads_total, 'count')}`,
+      `product_internal_list_failures_total=${formatMetricValue(data.metrics.product_internal_list_failures_total, 'count')}`,
+      `product_internal_list_duration_avg=${formatMetricValue(data.metrics.product_internal_list_duration, 'avg')}ms`,
+      `product_internal_list_duration_p95=${formatMetricValue(data.metrics.product_internal_list_duration, 'p(95)')}ms`,
+      '',
+    ].join('\n'),
+    [summaryPath]: JSON.stringify(data, null, 2),
+  };
+}
+
+function buildScenario() {
+  if (executor === 'rate') {
+    return {
+      executor: 'constant-arrival-rate',
+      rate,
+      timeUnit: '1s',
+      duration: __ENV.DURATION || '1m',
+      preAllocatedVUs,
+      maxVUs,
+      gracefulStop: '5s',
+    };
+  }
+
+  return {
+    executor: 'shared-iterations',
+    vus,
+    iterations,
+    maxDuration: __ENV.MAX_DURATION || '2m',
+    gracefulStop: '5s',
+  };
+}
+
+function readProductDetail(baseUrl, productId) {
+  const response = http.get(`${baseUrl}/api/v1/products/${productId}`, {
+    tags: {
+      name: 'get_product_detail',
+      experiment: __ENV.EXPERIMENT_NAME || 'product-cache-read-load',
+      target,
+    },
+  });
+  productDetailDuration.add(response.timings.duration);
+
+  const payload = parseJson(response);
+  const passed = check(response, {
+    'product detail status is 200': (res) => res.status === 200,
+    'product detail id matches': () => payload && Number(payload.id) === productId,
+  });
+
+  if (passed) {
+    productDetailReads.add(1);
+  } else {
+    productDetailFailures.add(1);
+  }
+}
+
+function readInternalProductList(internalBaseUrl, internalAuthSecret, productIdsToRead) {
+  const response = http.post(
+    `${internalBaseUrl}/api/v1/products/internal/list`,
+    JSON.stringify(productIdsToRead),
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Internal-Auth': internalAuthSecret,
+      },
+      tags: {
+        name: 'get_internal_product_list',
+        experiment: __ENV.EXPERIMENT_NAME || 'product-cache-read-load',
+        target,
+      },
+    }
+  );
+  productInternalListDuration.add(response.timings.duration);
+
+  const payload = parseJson(response);
+  const passed = check(response, {
+    'internal product list status is 200': (res) => res.status === 200,
+    'internal product list returns requested ids': () => containsAllProductIds(payload, productIdsToRead),
+  });
+
+  if (passed) {
+    productInternalReads.add(1);
+  } else {
+    productInternalFailures.add(1);
+  }
+}
+
+function warmDetailCache(baseUrl, productIdsToWarm) {
+  for (const productId of productIdsToWarm) {
+    const response = requestWithRetry(
+      () => http.get(`${baseUrl}/api/v1/products/${productId}`, { tags: { name: 'warm_product_detail' } }),
+      { action: `warm product detail productId=${productId}`, expectedStatuses: [200] }
+    );
+
+    if (!response || response.status !== 200) {
+      fail(`warm product detail failed: productId=${productId} status=${response && response.status}`);
+    }
+  }
+}
+
+function warmInternalCache(internalBaseUrl, internalAuthSecret, productIdsToWarm) {
+  const response = requestWithRetry(
+    () =>
+      http.post(
+        `${internalBaseUrl}/api/v1/products/internal/list`,
+        JSON.stringify(productIdsToWarm),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Internal-Auth': internalAuthSecret,
+          },
+          tags: { name: 'warm_internal_product_list' },
+        }
+      ),
+    { action: 'warm internal product list', expectedStatuses: [200] }
+  );
+
+  const payload = parseJson(response);
+  if (!response || response.status !== 200 || !containsAllProductIds(payload, productIdsToWarm)) {
+    fail(`warm internal product list failed: status=${response && response.status} body=${response && response.body}`);
+  }
+}
+
+function parseProductIds(rawValue) {
+  const parsed = rawValue
+    .split(',')
+    .map((value) => Number(value.trim()))
+    .filter((value) => Number.isFinite(value) && value > 0);
+
+  return [...new Set(parsed)];
+}
+
+function parsePositiveInteger(rawValue, defaultValue) {
+  const parsed = Number(rawValue || defaultValue);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return defaultValue;
+  }
+
+  return Math.floor(parsed);
+}
+
+function parseNonNegativeNumber(rawValue, defaultValue) {
+  const parsed = Number(rawValue || defaultValue);
+
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return defaultValue;
+  }
+
+  return parsed;
+}
+
+function pickBatch(ids, iteration) {
+  const size = Math.max(1, Math.min(productBatchSize, ids.length));
+  const result = [];
+
+  for (let i = 0; i < size; i += 1) {
+    result.push(ids[(iteration + i) % ids.length]);
+  }
+
+  return result;
+}
+
+function usesInternalEndpoint() {
+  return target === 'internal' || target === 'mixed';
+}
+
+function containsAllProductIds(payload, expectedProductIds) {
+  if (!Array.isArray(payload)) {
+    return false;
+  }
+
+  const actualIds = new Set(payload.map((item) => Number(item.id)));
+  return expectedProductIds.every((productId) => actualIds.has(productId));
+}
+
+function parseJson(response) {
+  if (!response) {
+    return null;
+  }
+
+  try {
+    return response.json();
+  } catch (error) {
+    return null;
+  }
+}
+
+function requestWithRetry(requestFn, options = {}) {
+  const {
+    action = 'request',
+    expectedStatuses = [200],
+    retryOnStatuses = [500, 502, 503, 504],
+    maxAttempts = 10,
+    backoffSeconds = 1,
+  } = options;
+
+  let lastResponse = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    lastResponse = requestFn();
+
+    if (lastResponse && expectedStatuses.includes(lastResponse.status)) {
+      return lastResponse;
+    }
+
+    const shouldRetry =
+      !lastResponse ||
+      retryOnStatuses.includes(lastResponse.status) ||
+      lastResponse.error_code !== 0;
+
+    if (!shouldRetry || attempt === maxAttempts) {
+      return lastResponse;
+    }
+
+    console.warn(
+      `${action} retrying: attempt=${attempt} status=${lastResponse.status} error=${lastResponse.error}`
+    );
+    sleep(backoffSeconds * attempt);
+  }
+
+  return lastResponse;
+}
+
+function formatMetricValue(metric, key) {
+  if (!metric || !metric.values || metric.values[key] === undefined) {
+    return '0';
+  }
+
+  return Number(metric.values[key]).toFixed(2);
+}

--- a/loadtest/run-product-cache-experiment.sh
+++ b/loadtest/run-product-cache-experiment.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+RUN_ID="${RUN_ID:-$(date +%s)}"
+TARGET="${TARGET:-${K6_TARGET:-internal}}"
+PRODUCT_IDS="${PRODUCT_IDS:-${K6_PRODUCT_IDS:-1,2,3}}"
+PRODUCT_BATCH_SIZE="${PRODUCT_BATCH_SIZE:-${K6_PRODUCT_BATCH_SIZE:-3}}"
+WARM_CACHE="${WARM_CACHE:-${K6_WARM_CACHE:-true}}"
+GATEWAY_HEALTH_URL="${GATEWAY_HEALTH_URL:-http://localhost:8080/actuator/health}"
+WAIT_MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS:-30}"
+WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS:-2}"
+WAIT_STABLE_SUCCESSES="${WAIT_STABLE_SUCCESSES:-3}"
+BASE_URL="${K6_BASE_URL:-http://api-gateway:8080}"
+DETAIL_BASE_URL="${K6_DETAIL_BASE_URL:-http://product-service:8082}"
+INTERNAL_BASE_URL="${K6_INTERNAL_BASE_URL:-http://product-service:8082}"
+INTERNAL_AUTH_SECRET="${INTERNAL_AUTH_SECRET:-${SECURITY_SERVICE_INTERNAL_SECRET:-${SECURITY_GATEWAY_INTERNAL_SECRET:-}}}"
+EXPERIMENT_PREFIX="${EXPERIMENT_PREFIX:-product-cache-${TARGET}}"
+EXECUTOR="${EXECUTOR:-${K6_EXECUTOR:-iterations}}"
+ITERATIONS="${ITERATIONS:-${K6_ITERATIONS:-3000}}"
+VUS="${VUS:-${K6_VUS:-50}}"
+CURRENT_CACHE_ENABLED=""
+
+if [[ "${TARGET}" != "detail" && "${TARGET}" != "internal" && "${TARGET}" != "mixed" ]]; then
+  echo "TARGET must be one of detail, internal, mixed. target=${TARGET}" >&2
+  exit 1
+fi
+
+if [[ "${EXECUTOR}" != "iterations" && "${EXECUTOR}" != "rate" ]]; then
+  echo "EXECUTOR must be one of iterations, rate. executor=${EXECUTOR}" >&2
+  exit 1
+fi
+
+if [[ "${TARGET}" != "detail" && -z "${INTERNAL_AUTH_SECRET}" ]]; then
+  echo "SECURITY_SERVICE_INTERNAL_SECRET or INTERNAL_AUTH_SECRET is required for target=${TARGET}." >&2
+  exit 1
+fi
+
+wait_for_gateway() {
+  local attempt=1
+
+  while (( attempt <= WAIT_MAX_ATTEMPTS )); do
+    if command -v curl >/dev/null 2>&1; then
+      if curl -fsS "${GATEWAY_HEALTH_URL}" >/dev/null 2>&1; then
+        echo "gateway_ready=true"
+        return 0
+      fi
+    elif command -v wget >/dev/null 2>&1; then
+      if wget -qO- "${GATEWAY_HEALTH_URL}" >/dev/null 2>&1; then
+        echo "gateway_ready=true"
+        return 0
+      fi
+    else
+      echo "Neither curl nor wget is available on the host." >&2
+      return 1
+    fi
+
+    echo "gateway_ready=false attempt=${attempt} url=${GATEWAY_HEALTH_URL}"
+    sleep "${WAIT_SLEEP_SECONDS}"
+    attempt=$((attempt + 1))
+  done
+
+  echo "Gateway did not become ready: ${GATEWAY_HEALTH_URL}" >&2
+  return 1
+}
+
+wait_for_http_from_k6_network() {
+  local url="$1"
+
+  echo "wait_http_url=${url}"
+  docker compose --profile loadtest run --no-deps --rm \
+    -e WAIT_URL="${url}" \
+    -e WAIT_MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS}" \
+    -e WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS}" \
+    -e WAIT_STABLE_SUCCESSES="${WAIT_STABLE_SUCCESSES}" \
+    k6 run /scripts/wait-http.js
+}
+
+wait_for_target_service() {
+  if [[ "${TARGET}" == "detail" || "${TARGET}" == "mixed" ]]; then
+    wait_for_http_from_k6_network "${DETAIL_BASE_URL}/actuator/health"
+  fi
+
+  if [[ "${TARGET}" == "internal" || "${TARGET}" == "mixed" ]]; then
+    if [[ "${INTERNAL_BASE_URL}" != "${DETAIL_BASE_URL}" || "${TARGET}" == "internal" ]]; then
+      wait_for_http_from_k6_network "${INTERNAL_BASE_URL}/actuator/health"
+    fi
+  fi
+}
+
+restart_product_service() {
+  local cache_enabled="$1"
+
+  echo "product_cache_enabled=${cache_enabled}"
+  PRODUCT_CACHE_ENABLED="${cache_enabled}" docker compose up -d --build product-service
+  CURRENT_CACHE_ENABLED="${cache_enabled}"
+  wait_for_gateway
+  wait_for_target_service
+}
+
+restore_cache_enabled() {
+  if [[ "${RESTORE_CACHE_ENABLED:-true}" == "true" && "${CURRENT_CACHE_ENABLED}" == "false" ]]; then
+    echo "restore_product_cache_enabled=true"
+    PRODUCT_CACHE_ENABLED=true docker compose up -d --build product-service >/dev/null
+  fi
+}
+
+flush_redis() {
+  echo "redis_flushdb=true"
+  docker compose exec -T redis redis-cli FLUSHDB >/dev/null
+}
+
+run_k6_phase() {
+  local cache_label="$1"
+  local cache_enabled="$2"
+  local experiment_name="${EXPERIMENT_PREFIX}-${cache_label}"
+  local summary_path="/results/${experiment_name}-${RUN_ID}.json"
+
+  restart_product_service "${cache_enabled}"
+  flush_redis
+  wait_for_target_service
+
+  cat <<EOF
+experiment=${experiment_name}
+run_id=${RUN_ID}
+target=${TARGET}
+warm_cache=${WARM_CACHE}
+product_ids=${PRODUCT_IDS}
+product_batch_size=${PRODUCT_BATCH_SIZE}
+executor=${EXECUTOR}
+iterations=${ITERATIONS}
+vus=${VUS}
+rate=${K6_RATE:-50}
+duration=${K6_DURATION:-1m}
+detail_base_url=${DETAIL_BASE_URL}
+internal_base_url=${INTERNAL_BASE_URL}
+summary_path=${summary_path}
+EOF
+
+  docker compose --profile loadtest run --rm \
+    -e RUN_ID="${RUN_ID}" \
+    -e EXPERIMENT_NAME="${experiment_name}" \
+    -e SUMMARY_PATH="${summary_path}" \
+    -e BASE_URL="${BASE_URL}" \
+    -e DETAIL_BASE_URL="${DETAIL_BASE_URL}" \
+    -e INTERNAL_BASE_URL="${INTERNAL_BASE_URL}" \
+    -e INTERNAL_AUTH_SECRET="${INTERNAL_AUTH_SECRET}" \
+    -e TARGET="${TARGET}" \
+    -e WARM_CACHE="${WARM_CACHE}" \
+    -e PRODUCT_IDS="${PRODUCT_IDS}" \
+    -e PRODUCT_BATCH_SIZE="${PRODUCT_BATCH_SIZE}" \
+    -e EXECUTOR="${EXECUTOR}" \
+    -e ITERATIONS="${ITERATIONS}" \
+    -e VUS="${VUS}" \
+    -e RATE="${K6_RATE:-50}" \
+    -e DURATION="${K6_DURATION:-1m}" \
+    -e PRE_ALLOCATED_VUS="${K6_PRE_ALLOCATED_VUS:-50}" \
+    -e MAX_VUS="${K6_MAX_VUS:-100}" \
+    -e SLEEP_BETWEEN="${K6_SLEEP_BETWEEN:-0}" \
+    k6 run /scripts/product-cache-read.js
+}
+
+trap restore_cache_enabled EXIT
+
+docker compose up -d mysql redpanda redis member-service product-service market-service api-gateway
+wait_for_gateway
+
+run_k6_phase "cache-off" "false"
+run_k6_phase "cache-on" "true"
+
+cat <<EOF
+result_cache_off=loadtest/results/${EXPERIMENT_PREFIX}-cache-off-${RUN_ID}.json
+result_cache_on=loadtest/results/${EXPERIMENT_PREFIX}-cache-on-${RUN_ID}.json
+EOF

--- a/loadtest/wait-http.js
+++ b/loadtest/wait-http.js
@@ -1,0 +1,83 @@
+import http from 'k6/http';
+import { fail, sleep } from 'k6';
+
+export const options = {
+  scenarios: {
+    wait_http_ready: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: __ENV.WAIT_MAX_DURATION || '2m',
+    },
+  },
+};
+
+export default function () {
+  const url = __ENV.WAIT_URL;
+  if (!url) {
+    fail('WAIT_URL is required.');
+  }
+
+  const maxAttempts = parsePositiveInteger(__ENV.WAIT_MAX_ATTEMPTS, 30);
+  const sleepSeconds = parsePositiveNumber(__ENV.WAIT_SLEEP_SECONDS, 2);
+  const stableSuccesses = parsePositiveInteger(__ENV.WAIT_STABLE_SUCCESSES, 3);
+  const expectedStatuses = parseExpectedStatuses(__ENV.WAIT_EXPECTED_STATUSES || '200');
+  let consecutiveSuccesses = 0;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const response = http.get(url, {
+      tags: {
+        name: 'wait_http_ready',
+      },
+    });
+
+    if (response && expectedStatuses.includes(response.status)) {
+      consecutiveSuccesses += 1;
+      console.log(
+        `http_ready=true url=${url} status=${response.status} consecutive_successes=${consecutiveSuccesses}`
+      );
+
+      if (consecutiveSuccesses >= stableSuccesses) {
+        return;
+      }
+    } else {
+      consecutiveSuccesses = 0;
+      console.warn(
+        `http_ready=false attempt=${attempt} url=${url} status=${response && response.status} error=${response && response.error}`
+      );
+    }
+
+    if (attempt < maxAttempts) {
+      sleep(sleepSeconds);
+    }
+  }
+
+  fail(`HTTP endpoint did not become ready: url=${url}`);
+}
+
+function parseExpectedStatuses(rawValue) {
+  return rawValue
+    .split(',')
+    .map((value) => Number(value.trim()))
+    .filter((value) => Number.isFinite(value));
+}
+
+function parsePositiveInteger(rawValue, defaultValue) {
+  const parsed = Number(rawValue || defaultValue);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return defaultValue;
+  }
+
+  return Math.floor(parsed);
+}
+
+function parsePositiveNumber(rawValue, defaultValue) {
+  const parsed = Number(rawValue || defaultValue);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return defaultValue;
+  }
+
+  return parsed;
+}

--- a/market-service/src/main/java/com/thock/back/market/app/CartService.java
+++ b/market-service/src/main/java/com/thock/back/market/app/CartService.java
@@ -11,7 +11,6 @@ import com.thock.back.market.domain.MarketMember;
 import com.thock.back.market.in.dto.req.CartItemAddRequest;
 import com.thock.back.market.in.dto.res.CartItemListResponse;
 import com.thock.back.market.in.dto.res.CartItemResponse;
-import com.thock.back.market.out.api.dto.ProductInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -87,11 +86,8 @@ public class CartService {
         Cart cart = marketSupport.findCartByBuyer(member)
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
 
-        // Product 정보 조회 - API Call
-        ProductInfo product = marketSupport.getProduct(request.productId());
-        if (product == null) {
-            throw new CustomException(ErrorCode.CART_PRODUCT_API_FAILED);
-        }
+        CartProductView product = cartProductViewRepository.findByProductId(request.productId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_INFO_NOT_FOUND));
 
         int existingQuantity = cart.getItems().stream()
                 .filter(item -> item.getProductId().equals(request.productId()))

--- a/market-service/src/test/java/com/thock/back/market/app/CartServiceTest.java
+++ b/market-service/src/test/java/com/thock/back/market/app/CartServiceTest.java
@@ -8,7 +8,6 @@ import com.thock.back.market.domain.CartProductViewRepository;
 import com.thock.back.market.domain.MarketMember;
 import com.thock.back.market.in.dto.req.CartItemAddRequest;
 import com.thock.back.market.in.dto.res.CartItemListResponse;
-import com.thock.back.market.out.api.dto.ProductInfo;
 import com.thock.back.shared.member.domain.MemberRole;
 import com.thock.back.shared.member.domain.MemberState;
 import org.junit.jupiter.api.DisplayName;
@@ -97,7 +96,7 @@ class CartServiceTest {
         Cart cart = new Cart(buyer);
         cart.addItem(100L, 4);
 
-        ProductInfo product = new ProductInfo(
+        CartProductView productView = new CartProductView(
                 100L,
                 2L,
                 "keyboard",
@@ -106,12 +105,13 @@ class CartServiceTest {
                 9000L,
                 5,
                 1,
-                "ON_SALE"
+                "ON_SALE",
+                false
         );
 
         given(marketSupport.findMemberById(memberId)).willReturn(Optional.of(buyer));
         given(marketSupport.findCartByBuyer(buyer)).willReturn(Optional.of(cart));
-        given(marketSupport.getProduct(100L)).willReturn(product);
+        given(cartProductViewRepository.findByProductId(100L)).willReturn(Optional.of(productView));
 
         assertThatThrownBy(() -> cartService.addCartItem(memberId, new CartItemAddRequest(100L, 1)))
                 .isInstanceOf(CustomException.class)
@@ -120,5 +120,6 @@ class CartServiceTest {
                     org.assertj.core.api.Assertions.assertThat(customException.getErrorCode())
                             .isEqualTo(ErrorCode.CART_PRODUCT_OUT_OF_STOCK);
                 });
+        verify(marketSupport, never()).getProduct(100L);
     }
 }

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/product-service/src/main/java/com/thock/back/product/app/ProductCreateService.java
+++ b/product-service/src/main/java/com/thock/back/product/app/ProductCreateService.java
@@ -1,5 +1,7 @@
 package com.thock.back.product.app;
 
+import com.thock.back.product.cache.ProductCacheSnapshot;
+import com.thock.back.product.cache.ProductCacheSyncService;
 import com.thock.back.product.domain.command.ProductCreateCommand;
 import com.thock.back.product.domain.entity.Product;
 import com.thock.back.product.domain.service.ProductAuthorizationValidator;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductCreateService {
     private final ProductRepository productRepository;
     private final ProductEventPublisher productEventPublisher;
+    private final ProductCacheSyncService productCacheSyncService;
     private final ProductAuthorizationValidator authorizationValidator;
 
     public Long createProduct(ProductCreateCommand command) {
@@ -35,8 +38,13 @@ public class ProductCreateService {
                 .detail(command.detail())
                 .build();
 
+        // DB 저장
         Product saved = productRepository.save(product);
 
+        // 캐시 저장
+        productCacheSyncService.saveAfterCommit(ProductCacheSnapshot.from(saved));
+
+        // 상품 동기화 이벤트 발행
         productEventPublisher.publish(ProductEvent.builder()
                 .productId(saved.getId())
                 .sellerId(saved.getSellerId())

--- a/product-service/src/main/java/com/thock/back/product/app/ProductManageService.java
+++ b/product-service/src/main/java/com/thock/back/product/app/ProductManageService.java
@@ -2,6 +2,8 @@ package com.thock.back.product.app;
 
 import com.thock.back.global.exception.CustomException;
 import com.thock.back.global.exception.ErrorCode;
+import com.thock.back.product.cache.ProductCacheSnapshot;
+import com.thock.back.product.cache.ProductCacheSyncService;
 import com.thock.back.product.domain.command.ProductUpdateCommand;
 import com.thock.back.product.domain.entity.Product;
 import com.thock.back.product.domain.service.ProductAuthorizationValidator;
@@ -21,6 +23,7 @@ public class ProductManageService {
 
     private final ProductRepository productRepository;
     private final ProductEventPublisher productEventPublisher;
+    private final ProductCacheSyncService productCacheSyncService;
     private final ProductAuthorizationValidator authorizationValidator;
 
     public Long updateProduct(ProductUpdateCommand command) {
@@ -29,6 +32,7 @@ public class ProductManageService {
 
         authorizationValidator.validateOwnership(product, command.requesterId(), command.role());
 
+        // 상품 수정
         product.modify(
                 command.name(),
                 command.price(),
@@ -40,6 +44,10 @@ public class ProductManageService {
                 command.detail()
         );
 
+        // 캐시 수정
+        productCacheSyncService.saveAfterCommit(ProductCacheSnapshot.from(product));
+
+        // 상품 동기화 이벤트 발행
         productEventPublisher.publish(ProductEvent.builder()
                 .productId(product.getId())
                 .sellerId(product.getSellerId())
@@ -74,8 +82,13 @@ public class ProductManageService {
         Integer reservedStock = product.getReservedStock();
         String imageUrl = product.getImageUrl();
 
+        // 상품 삭제
         productRepository.delete(product);
 
+        // 캐시 삭제
+        productCacheSyncService.evictAfterCommit(deletedId);
+
+        // 상품 동기화 이벤트 발행
         productEventPublisher.publish(ProductEvent.builder()
                 .productId(deletedId)
                 .sellerId(sellerId)

--- a/product-service/src/main/java/com/thock/back/product/app/ProductQueryService.java
+++ b/product-service/src/main/java/com/thock/back/product/app/ProductQueryService.java
@@ -2,6 +2,8 @@ package com.thock.back.product.app;
 
 import com.thock.back.global.exception.CustomException;
 import com.thock.back.global.exception.ErrorCode;
+import com.thock.back.product.cache.ProductCacheSnapshot;
+import com.thock.back.product.cache.ProductCacheStore;
 import com.thock.back.product.domain.Category;
 import com.thock.back.product.domain.entity.Product;
 import com.thock.back.product.in.dto.ProductDetailResponse;
@@ -10,18 +12,23 @@ import com.thock.back.product.in.dto.ProductSearchRequest;
 import com.thock.back.product.in.dto.internal.ProductInternalResponse;
 import com.thock.back.product.out.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class ProductQueryService {
     private final ProductRepository productRepository;
+    private final ProductCacheStore productCacheStore;
 
     public Page<ProductSearchResponse> searchProductsByCategory(Category category, Pageable pageable) {
         return productRepository.findByCategory(category, pageable)
@@ -29,17 +36,61 @@ public class ProductQueryService {
     }
 
     public ProductDetailResponse getProductById(Long id) {
-        Product product = productRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
-        return new ProductDetailResponse(product);
+        return productCacheStore.findById(id)
+                .map(snapshot -> {
+                    log.info("Product detail cache hit. productId={}", id);
+                    return snapshot.toDetailResponse();
+                })
+                .orElseGet(() -> {
+                    log.info("Product detail cache miss. productId={}", id);
+
+                    Product product = productRepository.findById(id)
+                            .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+                    ProductCacheSnapshot snapshot = ProductCacheSnapshot.from(product);
+                    productCacheStore.save(snapshot);
+
+                    return snapshot.toDetailResponse();
+                });
     }
 
     public List<ProductInternalResponse> getProductsByIds(List<Long> productIds) {
         if (productIds == null || productIds.isEmpty()) {
             return List.of();
         }
-        return productRepository.findAllByIdIn(productIds).stream()
-                .map(ProductInternalResponse::new)
+
+        Map<Long, ProductCacheSnapshot> cachedSnapshots = productCacheStore.findAllByIds(productIds);
+
+        List<Long> missedProductIds = productIds.stream()
+                .filter(productId -> !cachedSnapshots.containsKey(productId))
+                .distinct()
+                .toList();
+
+        if (!missedProductIds.isEmpty()) {
+            log.info("Product internal list cache miss. requestedCount={}, hitCount={}, missCount={}",
+                    productIds.size(),
+                    cachedSnapshots.size(),
+                    missedProductIds.size());
+
+            List<ProductCacheSnapshot> missedSnapshots = productRepository.findAllByIdIn(missedProductIds).stream()
+                    .map(ProductCacheSnapshot::from)
+                    .toList();
+
+            productCacheStore.saveAll(missedSnapshots);
+
+            for (ProductCacheSnapshot snapshot : missedSnapshots) {
+                cachedSnapshots.put(snapshot.id(), snapshot);
+            }
+        } else {
+            log.info("Product internal list cache hit. requestedCount={}, hitCount={}, missCount=0",
+                    productIds.size(),
+                    cachedSnapshots.size());
+        }
+
+        return productIds.stream()
+                .map(cachedSnapshots::get)
+                .filter(Objects::nonNull)
+                .map(ProductCacheSnapshot::toInternalResponse)
                 .toList();
     }
 

--- a/product-service/src/main/java/com/thock/back/product/app/ProductQueryService.java
+++ b/product-service/src/main/java/com/thock/back/product/app/ProductQueryService.java
@@ -10,6 +10,7 @@ import com.thock.back.product.in.dto.ProductDetailResponse;
 import com.thock.back.product.in.dto.ProductSearchResponse;
 import com.thock.back.product.in.dto.ProductSearchRequest;
 import com.thock.back.product.in.dto.internal.ProductInternalResponse;
+import com.thock.back.product.monitoring.ProductCacheMetrics;
 import com.thock.back.product.out.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ import java.util.Objects;
 public class ProductQueryService {
     private final ProductRepository productRepository;
     private final ProductCacheStore productCacheStore;
+    private final ProductCacheMetrics productCacheMetrics;
 
     public Page<ProductSearchResponse> searchProductsByCategory(Category category, Pageable pageable) {
         return productRepository.findByCategory(category, pageable)
@@ -39,10 +41,12 @@ public class ProductQueryService {
         return productCacheStore.findById(id)
                 .map(snapshot -> {
                     log.info("Product detail cache hit. productId={}", id);
+                    productCacheMetrics.recordDetailHit();
                     return snapshot.toDetailResponse();
                 })
                 .orElseGet(() -> {
                     log.info("Product detail cache miss. productId={}", id);
+                    productCacheMetrics.recordDetailMiss();
 
                     Product product = productRepository.findById(id)
                             .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
@@ -66,11 +70,17 @@ public class ProductQueryService {
                 .distinct()
                 .toList();
 
+        int hitCount = cachedSnapshots.size();
+        int missCount = missedProductIds.size();
+
         if (!missedProductIds.isEmpty()) {
             log.info("Product internal list cache miss. requestedCount={}, hitCount={}, missCount={}",
                     productIds.size(),
-                    cachedSnapshots.size(),
-                    missedProductIds.size());
+                    hitCount,
+                    missCount);
+
+            productCacheMetrics.recordInternalHit(hitCount);
+            productCacheMetrics.recordInternalMiss(missCount);
 
             List<ProductCacheSnapshot> missedSnapshots = productRepository.findAllByIdIn(missedProductIds).stream()
                     .map(ProductCacheSnapshot::from)
@@ -84,7 +94,9 @@ public class ProductQueryService {
         } else {
             log.info("Product internal list cache hit. requestedCount={}, hitCount={}, missCount=0",
                     productIds.size(),
-                    cachedSnapshots.size());
+                    hitCount);
+
+            productCacheMetrics.recordInternalHit(hitCount);
         }
 
         return productIds.stream()

--- a/product-service/src/main/java/com/thock/back/product/app/ProductStockService.java
+++ b/product-service/src/main/java/com/thock/back/product/app/ProductStockService.java
@@ -2,6 +2,8 @@ package com.thock.back.product.app;
 
 import com.thock.back.global.exception.CustomException;
 import com.thock.back.global.exception.ErrorCode;
+import com.thock.back.product.cache.ProductCacheSnapshot;
+import com.thock.back.product.cache.ProductCacheSyncService;
 import com.thock.back.product.domain.entity.Product;
 import com.thock.back.product.messaging.publisher.ProductEventPublisher;
 import com.thock.back.product.out.ProductRepository;
@@ -23,8 +25,8 @@ import java.util.stream.Collectors;
 public class ProductStockService {
 
     private final ProductRepository productRepository;
-
     private final ProductEventPublisher productEventPublisher;
+    private final ProductCacheSyncService productCacheSyncService;
 
     // 주문의 재고 변경 이벤트 처리 (예약, 해제, 커밋)
     @Transactional
@@ -72,6 +74,12 @@ public class ProductStockService {
                 throw new CustomException(ErrorCode.INVALID_REQUEST);
             }
         }
+
+        productCacheSyncService.saveAllAfterCommit(
+                products.stream()
+                        .map(ProductCacheSnapshot::from)
+                        .toList()
+        );
 
         for (Product product : products) {
             productEventPublisher.publish(ProductEvent.builder()

--- a/product-service/src/main/java/com/thock/back/product/cache/ProductCacheSnapshot.java
+++ b/product-service/src/main/java/com/thock/back/product/cache/ProductCacheSnapshot.java
@@ -1,0 +1,60 @@
+package com.thock.back.product.cache;
+
+import com.thock.back.product.domain.entity.Product;
+import com.thock.back.product.in.dto.ProductDetailResponse;
+import com.thock.back.product.in.dto.internal.ProductInternalResponse;
+
+public record ProductCacheSnapshot (
+        Long id,
+        Long sellerId,
+        String name,
+        String imageUrl,
+        Long price,
+        Long salePrice,
+        String description,
+        Integer stock,
+        Integer reservedStock,
+        String category,
+        String state
+) {
+    public static ProductCacheSnapshot from(Product product) {
+        return new ProductCacheSnapshot(
+                product.getId(),
+                product.getSellerId(),
+                product.getName(),
+                product.getImageUrl(),
+                product.getPrice(),
+                product.getSalePrice(),
+                product.getDescription(),
+                product.getStock(),
+                product.getReservedStock(),
+                product.getCategory().name(),
+                product.getState().name()
+        );
+    }
+
+    public ProductDetailResponse toDetailResponse() {
+        return new ProductDetailResponse(
+                id,
+                name,
+                salePrice,
+                description,
+                stock,
+                category
+        );
+    }
+
+    public ProductInternalResponse toInternalResponse() {
+        return new ProductInternalResponse(
+                id,
+                sellerId,
+                name,
+                imageUrl,
+                price,
+                salePrice,
+                stock,
+                reservedStock,
+                state
+        );
+    }
+}

--- a/product-service/src/main/java/com/thock/back/product/cache/ProductCacheStore.java
+++ b/product-service/src/main/java/com/thock/back/product/cache/ProductCacheStore.java
@@ -1,0 +1,127 @@
+package com.thock.back.product.cache;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductCacheStore {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${product.cache.enabled:false}")
+    private boolean cacheEnabled;
+
+    @Value("${product.cache.ttl-seconds:600}")
+    private long ttlSeconds;
+
+    public Optional<ProductCacheSnapshot> findById(Long productId) {
+        if (!cacheEnabled || productId == null) {
+            return Optional.empty();
+        }
+
+        String key = key(productId);
+        String rawValue = stringRedisTemplate.opsForValue().get(key);
+
+        if (rawValue == null) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(objectMapper.readValue(rawValue, ProductCacheSnapshot.class));
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to deserialize product cache. key={}", key, e);
+            stringRedisTemplate.delete(key);
+            return Optional.empty();
+        }
+    }
+
+    public Map<Long, ProductCacheSnapshot> findAllByIds(List<Long> productIds) {
+        if (!cacheEnabled || productIds == null || productIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<String> keys = productIds.stream()
+                .map(this::key)
+                .toList();
+
+        List<String> rawValues = stringRedisTemplate.opsForValue().multiGet(keys);
+        if (rawValues == null || rawValues.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, ProductCacheSnapshot> result = new HashMap<>();
+
+        for (int i = 0; i < productIds.size(); i++) {
+            String rawValue = rawValues.get(i);
+            if (rawValue == null) {
+                continue;
+            }
+
+            Long productId = productIds.get(i);
+            String key = keys.get(i);
+
+            try {
+                ProductCacheSnapshot snapshot =
+                        objectMapper.readValue(rawValue, ProductCacheSnapshot.class);
+                result.put(productId, snapshot);
+            } catch (JsonProcessingException e) {
+                log.warn("Failed to deserialize product cache. key={}", key, e);
+                stringRedisTemplate.delete(key);
+            }
+        }
+
+        return result;
+    }
+
+    public void save(ProductCacheSnapshot snapshot) {
+        if (!cacheEnabled || snapshot == null || snapshot.id() == null) {
+            return;
+        }
+
+        try {
+            String key = key(snapshot.id());
+            String payload = objectMapper.writeValueAsString(snapshot);
+
+            stringRedisTemplate.opsForValue()
+                    .set(key, payload, Duration.ofSeconds(ttlSeconds));
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize product cache. productId={}", snapshot.id(), e);
+        }
+    }
+
+    public void saveAll(List<ProductCacheSnapshot> snapshots) {
+        if (!cacheEnabled || snapshots == null || snapshots.isEmpty()) {
+            return;
+        }
+
+        for (ProductCacheSnapshot snapshot : snapshots) {
+            save();
+        }
+    }
+
+    public void evict(Long productId) {
+        if (!cacheEnabled || productId == null) {
+            return;
+        }
+
+        stringRedisTemplate.delete(key(productId));
+    }
+
+    private String  key(Long productId) {
+        return "product:detail:" + productId;
+    }
+}

--- a/product-service/src/main/java/com/thock/back/product/cache/ProductCacheStore.java
+++ b/product-service/src/main/java/com/thock/back/product/cache/ProductCacheStore.java
@@ -75,8 +75,7 @@ public class ProductCacheStore {
             String key = keys.get(i);
 
             try {
-                ProductCacheSnapshot snapshot =
-                        objectMapper.readValue(rawValue, ProductCacheSnapshot.class);
+                ProductCacheSnapshot snapshot = objectMapper.readValue(rawValue, ProductCacheSnapshot.class);
                 result.put(productId, snapshot);
             } catch (JsonProcessingException e) {
                 log.warn("Failed to deserialize product cache. key={}", key, e);
@@ -109,7 +108,7 @@ public class ProductCacheStore {
         }
 
         for (ProductCacheSnapshot snapshot : snapshots) {
-            save();
+            save(snapshot);
         }
     }
 

--- a/product-service/src/main/java/com/thock/back/product/cache/ProductCacheSyncService.java
+++ b/product-service/src/main/java/com/thock/back/product/cache/ProductCacheSyncService.java
@@ -1,0 +1,69 @@
+package com.thock.back.product.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ProductCacheSyncService {
+
+    private final ProductCacheStore productCacheStore;
+
+    public void saveAfterCommit(ProductCacheSnapshot snapshot) {
+        if (snapshot == null) {
+            return;
+        }
+
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            productCacheStore.save(snapshot);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                productCacheStore.save(snapshot);
+            }
+        });
+    }
+
+    public void saveAllAfterCommit(List<ProductCacheSnapshot> snapshots) {
+        if (snapshots == null || snapshots.isEmpty()) {
+            return;
+        }
+
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            productCacheStore.saveAll(snapshots);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                productCacheStore.saveAll(snapshots);
+            }
+        });
+    }
+
+    public void evictAfterCommit(Long productId) {
+        if (productId == null) {
+            return;
+        }
+
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            productCacheStore.evict(productId);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                productCacheStore.evict(productId);
+            }
+        });
+    }
+}

--- a/product-service/src/main/java/com/thock/back/product/monitoring/ProductCacheMetrics.java
+++ b/product-service/src/main/java/com/thock/back/product/monitoring/ProductCacheMetrics.java
@@ -1,0 +1,66 @@
+package com.thock.back.product.monitoring;
+
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class ProductCacheMetrics {
+
+    private final Counter detailHitCounter;
+    private final Counter detailMissCounter;
+    private final Counter internalHitCounter;
+    private final Counter internalMissCounter;
+    private final Counter internalHitItemCounter;
+    private final Counter internalMissItemCounter;
+
+    public ProductCacheMetrics(MeterRegistry meterRegistry) {
+        this.detailHitCounter = Counter.builder("product_cache_detail_hit_total")
+                .description("Total number of product detail cache hits")
+                .register(meterRegistry);
+
+        this.detailMissCounter = Counter.builder("product_cache_detail_miss_total")
+                .description("Total number of product detail cache misses")
+                .register(meterRegistry);
+
+        this.internalHitCounter = Counter.builder("product_cache_internal_hit_total")
+                .description("Total number of product internal list cache hits")
+                .register(meterRegistry);
+
+        this.internalMissCounter = Counter.builder("product_cache_internal_miss_total")
+                .description("Total number of product internal list cache misses")
+                .register(meterRegistry);
+
+        this.internalHitItemCounter = Counter.builder("product_cache_internal_hit_item_total")
+                .description("Total number of cached items returned from internal product list requests")
+                .register(meterRegistry);
+
+        this.internalMissItemCounter = Counter.builder("product_cache_internal_miss_item_total")
+                .description("Total number of missed items from internal product list requests")
+                .register(meterRegistry);
+    }
+
+    public void recordDetailHit() {
+        detailHitCounter.increment();
+    }
+
+    public void recordDetailMiss() {
+        detailMissCounter.increment();
+    }
+
+    public void recordInternalHit(int hitCount) {
+        if (hitCount > 0) {
+            internalHitCounter.increment();
+            internalHitItemCounter.increment(hitCount);
+        }
+    }
+
+    public void recordInternalMiss(int missCount) {
+        if (missCount > 0) {
+            internalMissCounter.increment();
+            internalMissItemCounter.increment(missCount);
+        }
+    }
+}

--- a/product-service/src/main/resources/application-docker.yml
+++ b/product-service/src/main/resources/application-docker.yml
@@ -26,3 +26,5 @@ swagger:
 product:
   inbox:
     enabled: true
+  cache:
+    enabled: true

--- a/product-service/src/main/resources/application-local.yml
+++ b/product-service/src/main/resources/application-local.yml
@@ -21,6 +21,8 @@ spring:
 product:
   inbox:
     enabled: true
+  cache:
+    enabled: true
 
 swagger:
   server:

--- a/product-service/src/main/resources/application-test.yml
+++ b/product-service/src/main/resources/application-test.yml
@@ -26,3 +26,5 @@ jwt:
 product:
   inbox:
     enabled: false
+  cache:
+    enabled: false

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -20,6 +20,13 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
 
+  # Redis
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      timeout: 2s
+
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET_KEY}
@@ -47,13 +54,6 @@ springdoc:
     path: /v3/api-docs
   swagger-ui:
     enabled: false
-
-# Redis
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
-      timeout: 2s
 
 product:
   inbox:

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -48,6 +48,13 @@ springdoc:
   swagger-ui:
     enabled: false
 
+# Redis
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      timeout: 2s
+
 product:
   inbox:
     enabled: true
@@ -87,3 +94,6 @@ product:
       interval-ms: 3600000
       retention-days: 7
       batch-size: 500
+  cache:
+    enabled: ${PRODUCT_CACHE_ENABLED:false}
+    ttl-seconds: ${PRODUCT_CACHE_TTL_SECONDS:600}


### PR DESCRIPTION
## 관련 이슈
Closes #35 

## 변경 내용
- 상품 조회 시 Redis cache-aside 방식으로 캐싱

## 확인 내용
- 변경 후에도 기존 동작 정상 작동 확인 
- K6 부하 테스트로 성능 향상 확인
