### PR TITLE
[BUG] Lua gate 이후 테스트 설정 정리

### DIFF
--- a/market-service/src/main/resources/application-test.yml
+++ b/market-service/src/main/resources/application-test.yml
@@ -17,10 +17,18 @@ spring:
     hibernate:
       ddl-auto: create-drop
 
+  task:
+    scheduling:
+      enabled: false
+
 custom:
   global:
     productServiceUrl: http://localhost:8082
     paymentServiceUrl: http://localhost:8084
+
+market:
+  metrics:
+    enabled: false
 
 jwt:
   secret: thock-test-jwt-secret-key-which-is-long-enough-32chars

--- a/product-service/src/main/java/com/thock/back/product/config/kafka/ProductKafkaDlqConfig.java
+++ b/product-service/src/main/java/com/thock/back/product/config/kafka/ProductKafkaDlqConfig.java
@@ -43,6 +43,9 @@ public class ProductKafkaDlqConfig {
     @Value("${product.kafka.listener.concurrency:1}")
     private int productKafkaListenerConcurrency;
 
+    @Value("${spring.kafka.listener.auto-startup:true}")
+    private boolean kafkaListenerAutoStartup;
+
     public ProductKafkaDlqConfig(
             @Qualifier("productConsumerFactory") ConsumerFactory<String, Object> consumerFactory,
             @Qualifier("productKafkaTemplate") KafkaTemplate<String, Object> kafkaTemplate
@@ -121,6 +124,7 @@ public class ProductKafkaDlqConfig {
         factory.setConcurrency(productKafkaListenerConcurrency);
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
         factory.setCommonErrorHandler(productKafkaErrorHandler); // 에러 핸들러 장착!
+        factory.setAutoStartup(kafkaListenerAutoStartup);
 
         return factory;
     }

--- a/product-service/src/main/java/com/thock/back/product/messaging/outbox/ProductOutboxCleanupScheduler.java
+++ b/product-service/src/main/java/com/thock/back/product/messaging/outbox/ProductOutboxCleanupScheduler.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@ConditionalOnProperty(prefix = "product.event", name = "publish-mode", havingValue = "outbox", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "product.outbox.cleanup", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class ProductOutboxCleanupScheduler {
 
     private final ProductOutboxEventRepository productOutboxEventRepository;
@@ -25,6 +25,9 @@ public class ProductOutboxCleanupScheduler {
 
     @Value("${product.outbox.enabled:true}")
     private boolean outboxEnabled = true;
+
+    @Value("${product.event.publish-mode:outbox}")
+    private String publishMode = "outbox";
 
     @Value("${product.outbox.cleanup.enabled:true}")
     private boolean cleanupEnabled = true;
@@ -38,7 +41,7 @@ public class ProductOutboxCleanupScheduler {
     @Scheduled(fixedDelayString = "${product.outbox.cleanup.interval-ms:3600000}") // 1시간마다 실행
     @Transactional
     public void cleanupSentEvents() {
-        if (!outboxEnabled || !cleanupEnabled) {
+        if (!outboxEnabled || !cleanupEnabled || !"outbox".equalsIgnoreCase(publishMode)) {
             return;
         }
 

--- a/product-service/src/main/java/com/thock/back/product/messaging/outbox/ProductOutboxPoller.java
+++ b/product-service/src/main/java/com/thock/back/product/messaging/outbox/ProductOutboxPoller.java
@@ -37,7 +37,7 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@ConditionalOnProperty(prefix = "product.event", name = "publish-mode", havingValue = "outbox", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "product.outbox.poller", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class ProductOutboxPoller {
 
     private static final int BATCH_SIZE = 100;
@@ -49,6 +49,9 @@ public class ProductOutboxPoller {
 
     @Value("${product.outbox.enabled:true}")
     private boolean outboxEnabled = true;
+
+    @Value("${product.event.publish-mode:outbox}")
+    private String publishMode = "outbox";
 
     @Value("${product.outbox.poller.after-send-delay-ms:0}")
     private long afterSendDelayMs = 0L;
@@ -65,7 +68,7 @@ public class ProductOutboxPoller {
     @Scheduled(fixedDelayString = "${product.outbox.poller.interval-ms:3000}")
     @Transactional
     public void pollAndPublish() {
-        if (!outboxEnabled) {
+        if (!outboxEnabled || !"outbox".equalsIgnoreCase(publishMode)) {
             return;
         }
 

--- a/product-service/src/main/java/com/thock/back/product/monitoring/ProductStockReservationPressureMetrics.java
+++ b/product-service/src/main/java/com/thock/back/product/monitoring/ProductStockReservationPressureMetrics.java
@@ -2,7 +2,6 @@ package com.thock.back.product.monitoring;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -11,7 +10,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.thock.back.product.stock.ProductStockRedisReserveResult;
 
 @Component
-@ConditionalOnProperty(prefix = "product.metrics", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class ProductStockReservationPressureMetrics {
 
     private final AtomicLong redisPreRejectedCount = new AtomicLong(0);

--- a/product-service/src/main/resources/application-test.yml
+++ b/product-service/src/main/resources/application-test.yml
@@ -1,4 +1,13 @@
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    listener:
+      auto-startup: false
+
   datasource:
     url: ${TEST_DB_URL:jdbc:mysql://localhost:3307/test_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
     username: ${TEST_DB_USERNAME:test}
@@ -16,6 +25,10 @@ spring:
     job:
       enabled: false
 
+  task:
+    scheduling:
+      enabled: false
+
 # 테스트에서는 환경 변수 대신 application-test.yml에 JWT 시크릿 키를 직접 설정
 jwt:
   secret: thock-test-jwt-secret-key-which-is-long-enough-32chars
@@ -27,4 +40,6 @@ product:
   inbox:
     enabled: false
   cache:
+    enabled: false
+  metrics:
     enabled: false

--- a/product-service/src/main/resources/application-test.yml
+++ b/product-service/src/main/resources/application-test.yml
@@ -2,6 +2,7 @@ spring:
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+      - org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
 
   kafka:
     bootstrap-servers: localhost:9092
@@ -37,6 +38,14 @@ jwt:
   issuer: "thock-test"
 
 product:
+  event:
+    publish-mode: direct
+  outbox:
+    enabled: false
+    poller:
+      enabled: false
+    cleanup:
+      enabled: false
   inbox:
     enabled: false
   cache:

--- a/product-service/src/test/java/com/thock/back/product/app/ProductStockConcurrencyIntegrationTest.java
+++ b/product-service/src/test/java/com/thock/back/product/app/ProductStockConcurrencyIntegrationTest.java
@@ -26,7 +26,16 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = ProductServiceApplication.class)
+@SpringBootTest(
+        classes = ProductServiceApplication.class,
+        properties = {
+                "product.event.publish-mode=outbox",
+                "product.outbox.enabled=true",
+                "product.outbox.poller.enabled=false",
+                "product.outbox.cleanup.enabled=false",
+                "product.inbox.enabled=false"
+        }
+)
 @ActiveProfiles("test")
 class ProductStockConcurrencyIntegrationTest {
 

--- a/product-service/src/test/java/com/thock/back/product/in/ProductKafkaDlqIntegrationTest.java
+++ b/product-service/src/test/java/com/thock/back/product/in/ProductKafkaDlqIntegrationTest.java
@@ -36,8 +36,9 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -99,11 +100,17 @@ class ProductKafkaDlqIntegrationTest {
     @DisplayName("successful processing does not publish to the DLQ")
     void handle_whenProcessingSucceeds_doesNotSendToDlq() throws Exception {
         MarketOrderStockChangedEvent event = stockChangedEvent("ORDER-SUCCESS");
-        doNothing().when(productStockService).handle(any(MarketOrderStockChangedEvent.class));
+        when(productStockService.handleKafka(
+                any(MarketOrderStockChangedEvent.class),
+                anyString(),
+                anyString(),
+                anyString()
+        )).thenReturn(true);
 
         kafkaTemplate.send(KafkaTopics.MARKET_ORDER_STOCK_CHANGED, event).get(5, TimeUnit.SECONDS);
 
-        verify(productStockService, timeout(5000).times(1)).handle(any(MarketOrderStockChangedEvent.class));
+        verify(productStockService, timeout(5000).times(1))
+                .handleKafka(any(MarketOrderStockChangedEvent.class), anyString(), anyString(), anyString());
         assertThat(dlqProbe.poll(1500, TimeUnit.MILLISECONDS)).isNull();
     }
 
@@ -114,7 +121,7 @@ class ProductKafkaDlqIntegrationTest {
         MarketOrderStockChangedEvent event = stockChangedEvent("ORDER-CUSTOM-ERROR");
         doThrow(new CustomException(ErrorCode.INVALID_REQUEST))
                 .when(productStockService)
-                .handle(any(MarketOrderStockChangedEvent.class));
+                .handleKafka(any(MarketOrderStockChangedEvent.class), anyString(), anyString(), anyString());
 
         kafkaTemplate.send(KafkaTopics.MARKET_ORDER_STOCK_CHANGED, event).get(5, TimeUnit.SECONDS);
 
@@ -125,7 +132,8 @@ class ProductKafkaDlqIntegrationTest {
         assertThat(dlqMessage.originalTopic()).isEqualTo(KafkaTopics.MARKET_ORDER_STOCK_CHANGED);
         assertThat(dlqMessage.exceptionClass()).contains("ListenerExecutionFailedException");
         assertThat(dlqMessage.causeClass()).contains(CustomException.class.getName());
-        verify(productStockService, timeout(5000).times(1)).handle(any(MarketOrderStockChangedEvent.class));
+        verify(productStockService, timeout(5000).times(1))
+                .handleKafka(any(MarketOrderStockChangedEvent.class), anyString(), anyString(), anyString());
     }
 
     // 일반 RuntimeException 발생 시 최초 1회 + 재시도 2회 후 DLQ 전송 (총 3회 시도)
@@ -135,7 +143,7 @@ class ProductKafkaDlqIntegrationTest {
         MarketOrderStockChangedEvent event = stockChangedEvent("ORDER-RUNTIME-ERROR");
         doThrow(new RetryableKafkaProcessingException("temporary failure"))
                 .when(productStockService)
-                .handle(any(MarketOrderStockChangedEvent.class));
+                .handleKafka(any(MarketOrderStockChangedEvent.class), anyString(), anyString(), anyString());
 
         kafkaTemplate.send(KafkaTopics.MARKET_ORDER_STOCK_CHANGED, event).get(5, TimeUnit.SECONDS);
 
@@ -146,7 +154,8 @@ class ProductKafkaDlqIntegrationTest {
         assertThat(dlqMessage.originalTopic()).isEqualTo(KafkaTopics.MARKET_ORDER_STOCK_CHANGED);
         assertThat(dlqMessage.exceptionClass()).contains("ListenerExecutionFailedException");
         assertThat(dlqMessage.causeClass()).contains(RetryableKafkaProcessingException.class.getName());
-        verify(productStockService, timeout(10000).times(3)).handle(any(MarketOrderStockChangedEvent.class));
+        verify(productStockService, timeout(10000).times(3))
+                .handleKafka(any(MarketOrderStockChangedEvent.class), anyString(), anyString(), anyString());
     }
 
     private MarketOrderStockChangedEvent stockChangedEvent(String orderNumber) {

--- a/product-service/src/test/java/com/thock/back/product/in/ProductKafkaInboxIntegrationTest.java
+++ b/product-service/src/test/java/com/thock/back/product/in/ProductKafkaInboxIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.ContainerTestUtils;
 import org.springframework.test.context.ActiveProfiles;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Counter;
 import org.springframework.test.annotation.DirtiesContext;
 
 import java.util.List;
@@ -40,7 +41,8 @@ import static org.assertj.core.api.Assertions.assertThat;
                 "spring.kafka.listener.auto-startup=true",
                 "spring.kafka.consumer.auto-offset-reset=earliest",
                 "product.inbox.enabled=true",
-                "product.inbox.cleanup.enabled=false"
+                "product.inbox.cleanup.enabled=false",
+                "product.metrics.enabled=true"
         }
 )
 @EmbeddedKafka(
@@ -118,10 +120,10 @@ class ProductKafkaInboxIntegrationTest {
 
         waitUntil(() -> {
             Product productAfterEvent = productRepository.findById(productId).orElseThrow();
-            double duplicateIgnoredCount = meterRegistry
+            Counter duplicateIgnoredCounter = meterRegistry
                     .find("product_inbox_duplicate_ignored_total")
-                    .counter()
-                    .count();
+                    .counter();
+            double duplicateIgnoredCount = duplicateIgnoredCounter == null ? 0 : duplicateIgnoredCounter.count();
             return productAfterEvent.getReservedStock() == 1
                     && productAfterEvent.getStock() == 10
                     && productInboxEventRepository.count() == 1

--- a/product-service/src/test/java/com/thock/back/product/in/ProductKafkaListenerTest.java
+++ b/product-service/src/test/java/com/thock/back/product/in/ProductKafkaListenerTest.java
@@ -3,7 +3,6 @@ package com.thock.back.product.in;
 import com.thock.back.global.kafka.KafkaTopics;
 import com.thock.back.product.app.ProductStockService;
 import com.thock.back.product.in.idempotency.ProductInboundEventIdempotencyKeyResolver;
-import com.thock.back.product.messaging.inbox.ProductInboxGuard;
 import com.thock.back.shared.market.domain.StockEventType;
 import com.thock.back.shared.market.dto.StockOrderItemDto;
 import com.thock.back.shared.market.event.MarketOrderStockChangedEvent;
@@ -13,19 +12,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-
-/**
- Listener의 InBox 최초/InBox 중복/InBox 비활성화 분기 테스트
- **/
 
 @ExtendWith(MockitoExtension.class)
 class ProductKafkaListenerTest {
@@ -36,70 +29,84 @@ class ProductKafkaListenerTest {
     private ProductStockService productStockService;
 
     @Mock
-    private ObjectProvider<ProductInboxGuard> inboxGuardProvider;
-
-    @Mock
-    private ProductInboxGuard inboxGuard;
-
-    @Mock
     private ProductInboundEventIdempotencyKeyResolver keyResolver;
 
     private ProductKafkaListener listener;
 
     @BeforeEach
     void setUp() {
-        listener = new ProductKafkaListener(productStockService, inboxGuardProvider, keyResolver);
+        listener = new ProductKafkaListener(productStockService, keyResolver);
         ReflectionTestUtils.setField(listener, "consumerGroup", CONSUMER_GROUP);
     }
 
     @Test
-    @DisplayName("handle processes the stock event when inbox claim succeeds")
-    void handle_whenClaimed_processesEvent() {
+    @DisplayName("handle processes the stock event when kafka path returns processed")
+    void handle_whenProcessed_logsSuccessPath() {
         MarketOrderStockChangedEvent event = stockChangedEvent("ORDER-1", StockEventType.RESERVE);
 
         when(keyResolver.stockChanged(event)).thenReturn("stock:ORDER-1:RESERVE");
-        when(inboxGuardProvider.getIfAvailable()).thenReturn(inboxGuard);
-        when(inboxGuard.tryClaim(
-                "stock:ORDER-1:RESERVE",
+        when(productStockService.handleKafka(
+                event,
                 KafkaTopics.MARKET_ORDER_STOCK_CHANGED,
+                "stock:ORDER-1:RESERVE",
                 CONSUMER_GROUP
         )).thenReturn(true);
 
         listener.handle(event, 0, "ORDER-1");
 
-        verify(productStockService).handle(event);
+        verify(productStockService).handleKafka(
+                event,
+                KafkaTopics.MARKET_ORDER_STOCK_CHANGED,
+                "stock:ORDER-1:RESERVE",
+                CONSUMER_GROUP
+        );
     }
 
     @Test
-    @DisplayName("handle skips the stock event when inbox claim reports a duplicate")
+    @DisplayName("handle skips the stock event when kafka path reports duplicate")
     void handle_whenDuplicate_skipsEvent() {
         MarketOrderStockChangedEvent event = stockChangedEvent("ORDER-2", StockEventType.RELEASE);
 
         when(keyResolver.stockChanged(event)).thenReturn("stock:ORDER-2:RELEASE");
-        when(inboxGuardProvider.getIfAvailable()).thenReturn(inboxGuard);
-        when(inboxGuard.tryClaim(
-                "stock:ORDER-2:RELEASE",
+        when(productStockService.handleKafka(
+                event,
                 KafkaTopics.MARKET_ORDER_STOCK_CHANGED,
+                "stock:ORDER-2:RELEASE",
                 CONSUMER_GROUP
         )).thenReturn(false);
 
         listener.handle(event, 0, "ORDER-2");
 
-        verify(productStockService, never()).handle(event);
+        verify(productStockService).handleKafka(
+                event,
+                KafkaTopics.MARKET_ORDER_STOCK_CHANGED,
+                "stock:ORDER-2:RELEASE",
+                CONSUMER_GROUP
+        );
     }
 
     @Test
-    @DisplayName("handle processes the stock event without inbox when the guard bean is unavailable")
-    void handle_whenInboxDisabled_processesEvent() {
+    @DisplayName("handle propagates listener metadata to kafka stock handler")
+    void handle_propagatesListenerMetadata() {
         MarketOrderStockChangedEvent event = stockChangedEvent("ORDER-3", StockEventType.COMMIT);
 
         when(keyResolver.stockChanged(event)).thenReturn("stock:ORDER-3:COMMIT");
-        when(inboxGuardProvider.getIfAvailable()).thenReturn(null);
+        when(productStockService.handleKafka(
+                event,
+                KafkaTopics.MARKET_ORDER_STOCK_CHANGED,
+                "stock:ORDER-3:COMMIT",
+                CONSUMER_GROUP
+        )).thenReturn(true);
 
         listener.handle(event, 0, "ORDER-3");
 
-        verify(productStockService).handle(event);
-        verifyNoInteractions(inboxGuard);
+        verify(productStockService).handleKafka(
+                event,
+                KafkaTopics.MARKET_ORDER_STOCK_CHANGED,
+                "stock:ORDER-3:COMMIT",
+                CONSUMER_GROUP
+        );
+        verify(productStockService, never()).handle(event);
     }
 
     private MarketOrderStockChangedEvent stockChangedEvent(String orderNumber, StockEventType eventType) {

--- a/product-service/src/test/java/com/thock/back/product/messaging/outbox/ProductOutboxCleanupSchedulerIntegrationTest.java
+++ b/product-service/src/test/java/com/thock/back/product/messaging/outbox/ProductOutboxCleanupSchedulerIntegrationTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -39,9 +38,6 @@ class ProductOutboxCleanupSchedulerIntegrationTest {
 
     @Autowired
     private TransactionTemplate transactionTemplate;
-
-    @MockitoBean
-    private ProductOutboxPoller productOutboxPoller;
 
     @AfterEach
     void tearDown() {

--- a/product-service/src/test/java/com/thock/back/product/messaging/outbox/ProductOutboxEventPublisherIntegrationTest.java
+++ b/product-service/src/test/java/com/thock/back/product/messaging/outbox/ProductOutboxEventPublisherIntegrationTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
 import java.util.Map;
@@ -52,10 +51,6 @@ class ProductOutboxEventPublisherIntegrationTest {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    // Scheduled poller가 테스트 도중 row 상태를 바꾸지 않도록 mock으로 교체한다.
-    @MockitoBean
-    private ProductOutboxPoller productOutboxPoller;
 
     @AfterEach
     void tearDown() {


### PR DESCRIPTION
## 관련 이슈
Closes #39

## 변경 내용
- ProductKafkaListenerTest를 현재 ProductKafkaListener 생성자와 handleKafka 호출 구조에 맞게 수정했습니다.
- product-service test 프로필에서 Kafka auto-config, listener startup, scheduling, metrics를 비활성화했습니다.
- market-service test 프로필에서 scheduling을 비활성화해 테스트 환경 노이즈를 줄였습니다.

## 확인 내용
- product-service의 ProductKafkaListenerTest가 통과하는 것을 확인했습니다.
- 전체 test 실행 기준 기존 product-service compileTestJava 실패 원인이 제거된 것을 확인했습니다.