### PR TITLE
[FEAT] #이슈번호 주문 조회 JPA 로딩 최적화 및 응답시간 검증

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
     environment:
       TZ: Asia/Seoul
       JAVA_TOOL_OPTIONS: "-Duser.timezone=Asia/Seoul -Xms256m -Xmx512m"
-      SPRING_PROFILES_ACTIVE: docker
+      SPRING_PROFILES_ACTIVE: ${MARKET_SERVICE_PROFILES_ACTIVE:-docker}
       MYSQL_HOST: mysql
       MYSQL_PORT: 3306
       MYSQL_DATABASE: thock_market_db

--- a/docs/order-query-jpa-optimization-analysis.md
+++ b/docs/order-query-jpa-optimization-analysis.md
@@ -1,0 +1,305 @@
+# 주문 조회 JPA 최적화 분석
+
+## 목표
+
+주문 목록/상세 조회에서 `LAZY` 연관 로딩으로 인해 발생하는 `N+1` 문제를 제거하고, 이를 쿼리 수와 응답시간으로 검증한다.
+
+대상 경로는 다음 두 가지다.
+
+- 주문 목록 조회: `getMyOrders()`
+- 주문 상세 조회: `getOrderDetail()`
+
+---
+
+## 문제 상황
+
+기존 주문 조회는 `Order`만 먼저 조회한 뒤, 응답 DTO 변환 과정에서 `order.getItems()`를 순회했다.
+
+핵심 문제는 다음이다.
+
+- `Order.items`는 `LAZY`
+- `OrderDetailResponse.from(order)`가 `order.getItems()`에 접근
+- 주문 목록 조회 시 주문 수만큼 `items` 추가 쿼리가 발생
+
+즉 목록 조회는 구조적으로 다음과 같았다.
+
+1. 주문 목록 1회 조회
+2. 각 주문의 `items` lazy 조회
+
+주문이 `N`건이면 전체 쿼리는 `N+1`이 된다.
+
+상세 조회도 같은 원리로:
+
+1. 주문 1회 조회
+2. `items` lazy 조회 1회
+
+총 2쿼리가 발생했다.
+
+---
+
+## 원인 코드
+
+기존 병목의 핵심은 DTO 변환 시점의 연관 컬렉션 접근이었다.
+
+- `OrderService.getMyOrders()`
+- `OrderService.getOrderDetail()`
+- `OrderDetailResponse.from(order)`
+
+`OrderDetailResponse.from(order)`는 아래 형태로 동작한다.
+
+```java
+order.getItems().stream()
+    .map(OrderItemDto::from)
+    .toList();
+```
+
+즉 서비스 계층에서는 단순 조회처럼 보이지만, 실제로는 응답 생성 시점에 `items` 컬렉션이 초기화되면서 추가 SQL이 발생한다.
+
+---
+
+## 최적화 방향
+
+이번 개선의 목표는 인덱스나 실행계획이 아니라, **JPA 연관 로딩 구조 자체를 바꾸는 것**이었다.
+
+선택한 방식은 `fetch join`이다.
+
+이유:
+
+- 문제의 원인이 `LAZY` 연관 컬렉션 초기화였음
+- 필요한 연관 데이터가 `Order.items`로 명확했음
+- 목록/상세 모두 읽기 전용 조회라 `fetch join` 적용이 자연스러움
+
+즉 `Order`를 가져올 때 `items`도 함께 로딩하도록 Repository 쿼리를 분리했다.
+
+---
+
+## 구현 내용
+
+### 1. 주문 목록 조회 전용 fetch join 쿼리 추가
+
+`OrderRepository`
+
+```java
+@Query("""
+        select distinct o
+        from Order o
+        left join fetch o.items
+        where o.buyer.id = :buyerId
+        order by o.createdAt desc
+        """)
+List<Order> findDetailsByBuyerIdOrderByCreatedAtDesc(@Param("buyerId") Long buyerId);
+```
+
+설명:
+
+- `left join fetch o.items`로 `OrderItem`을 함께 조회
+- `distinct`는 `Order 1 : N OrderItem` 조인으로 루트 엔티티가 중복되는 것을 방지
+
+### 2. 주문 상세 조회 전용 fetch join 쿼리 추가
+
+```java
+@Query("""
+        select distinct o
+        from Order o
+        left join fetch o.items
+        where o.id = :orderId
+        """)
+Optional<Order> findDetailById(@Param("orderId") Long orderId);
+```
+
+### 3. 서비스 계층에서 전용 조회 메서드 사용
+
+- `getMyOrders()`는 `findDetailsByBuyerIdOrderByCreatedAtDesc()`
+- `getOrderDetail()`는 `findDetailById()`
+
+즉 변경의 본질은:
+
+- 기존: `Order` 조회 후 DTO 변환 중 연관 컬렉션 lazy 로딩
+- 변경: `Order` 조회 시 `items`까지 한 번에 로딩
+
+---
+
+## 쿼리 수 검증
+
+검증은 Hibernate Statistics를 사용했다.
+
+테스트 파일:
+
+- `market-service/src/test/java/com/thock/back/market/app/OrderServiceQueryOptimizationTest.java`
+
+기준 데이터:
+
+- 주문 5건
+- 주문당 아이템 2건
+
+검증 결과:
+
+| 케이스 | Baseline | Optimized | 개선 |
+|---|---:|---:|---:|
+| 주문 목록 조회 | 6 queries | 1 query | 83.3% 감소 |
+| 주문 상세 조회 | 2 queries | 1 query | 50.0% 감소 |
+
+해석:
+
+- 목록 조회는 `N+1 -> 1`
+- 상세 조회는 `2 -> 1`
+
+즉 이번 개선은 “체감상 빨라진 것 같다”가 아니라, **SQL 실행 수 자체를 줄였다는 점**이 먼저 입증됐다.
+
+### 왜 주문당 상품 5개인데 쿼리가 6개인가
+
+여기서 헷갈리기 쉬운 포인트가 있다.
+
+`Order.items`는 개별 `OrderItem`을 하나씩 가져오는 구조가 아니라, **주문 1건에 연결된 `OrderItem` 컬렉션 전체를 한 번에 초기화하는 구조**다.
+
+즉 `OrderDetailResponse.from(order)`에서:
+
+```java
+order.getItems().stream()
+    .map(OrderItemDto::from)
+    .toList();
+```
+
+이 코드가 실행될 때,
+
+- 아이템 5개면 5번 쿼리
+
+가 아니라,
+
+- 해당 주문의 `items` 전체를 조회하는 쿼리 1번
+
+이 실행된다.
+
+Hibernate는 대략 아래 형태의 SQL로 컬렉션을 초기화한다.
+
+```sql
+select *
+from market_order_items
+where order_id = ?
+```
+
+즉 테스트에서 주문 5건, 주문당 아이템 2건이었다면 baseline `6쿼리`는:
+
+- 주문 목록 조회 1쿼리
+- 각 주문의 items 컬렉션 조회 5쿼리
+
+를 뜻한다.
+
+즉 이 문제는 “아이템 개수만큼 쿼리”가 아니라, **주문 개수만큼 컬렉션 조회가 추가되는 N+1** 문제다.
+
+---
+
+## 응답시간 검증
+
+쿼리 수 감소만으로 끝내지 않고, 실험용 endpoint와 k6 스크립트를 추가해 baseline/optimized 응답시간도 비교했다.
+
+실험 인프라:
+
+- `market-service/src/main/java/com/thock/back/market/experiment/OrderQueryExperimentService.java`
+- `market-service/src/main/java/com/thock/back/market/experiment/OrderQueryExperimentController.java`
+- `loadtest/order-query-read.js`
+- `loadtest/run-order-query-experiment.sh`
+
+실험 방식:
+
+- `experiment` 프로필에서 baseline endpoint와 optimized endpoint를 같이 노출
+- 동일 데이터셋을 reset/seed 후 두 경로를 각각 측정
+- baseline: lazy 조회 경로
+- optimized: fetch join 조회 경로
+
+조건:
+
+- 주문 100건
+- 주문당 상품 5개
+- k6 `300 iterations`
+- `20 VUs`
+- 3회 반복
+
+유효 run:
+
+- `1775998763`
+- `1775998834`
+- `1775998872`
+
+중앙값 기준 결과:
+
+| 항목 | Baseline | Optimized | 개선 |
+|---|---:|---:|---:|
+| avg | 315.76ms | 36.86ms | 88.3% 감소 |
+| p95 | 461.39ms | 62.41ms | 86.5% 감소 |
+
+---
+
+## 왜 응답시간까지 개선됐는가
+
+이번 개선은 인덱스 추가가 아니라 **왕복 SQL 수 감소**가 핵심이었다.
+
+주문 목록 조회 기준으로 보면:
+
+- 기존: 주문 1회 + 각 주문의 items lazy 조회
+- 변경: 주문 + items를 한 번에 조회
+
+즉 응답 생성 과정에서 발생하던 다수의 DB round trip을 제거했기 때문에, 쿼리 수 감소가 응답시간 개선으로 직접 이어졌다.
+
+이번 사례는 상품 검색 튜닝과 달리:
+
+- 병목 원인이 명확했고
+- 개선 수단이 병목과 정확히 맞물렸고
+- 그 결과 쿼리 수와 응답시간이 함께 개선됐다
+
+---
+
+## 이번 작업에서 배운 점
+
+### 1. JPA 조회 최적화는 실행계획보다 로딩 구조가 먼저일 수 있다
+
+이번 문제는 인덱스가 아니라 `LAZY` 연관 로딩 구조가 원인이었다.
+
+즉 조회 성능 문제는 항상:
+
+- 인덱스
+- SQL 실행계획
+
+에서만 시작하는 것이 아니라,
+
+- 엔티티 연관관계
+- DTO 변환 시점
+- fetch 전략
+
+에서 시작할 수 있다.
+
+### 2. DTO 변환 코드도 쿼리 발생 지점이 될 수 있다
+
+서비스 계층에서 조회 메서드는 단순해 보여도, DTO 조립 시 `getItems()` 같은 접근이 실제 추가 쿼리를 만든다.
+
+즉 JPA 성능 문제는 Repository 메서드만 보지 말고, **응답 조립 코드까지 같이 봐야 한다.**
+
+### 3. 검증은 두 단계로 나눠야 한다
+
+이번에는 아래 순서로 검증했다.
+
+1. Hibernate Statistics로 쿼리 수 감소 검증
+2. k6로 응답시간 개선 검증
+
+이 방식이 좋았던 이유:
+
+- 쿼리 수 감소는 구조 개선 증거
+- 응답시간 감소는 사용자 관점 성과
+
+둘을 같이 잡을 수 있었기 때문이다.
+
+---
+
+## 최종 정리
+
+이번 개선의 핵심은 다음 한 줄로 정리할 수 있다.
+
+> 주문 목록·상세 조회에서 LAZY 연관 로딩으로 발생하던 N+1을 fetch join으로 제거해, 목록 조회를 `N+1 -> 1`, 상세 조회를 `2 -> 1`로 줄였고, 주문 100건·주문당 상품 5개 기준 3회 반복 부하 실험 중앙값에서 `avg 88.3%`, `p95 86.5%` 개선했다.
+
+즉 이번 사례는:
+
+- JPA 연관 로딩 문제를 정확히 인식했고
+- Repository 쿼리를 목적에 맞게 분리했으며
+- 쿼리 수와 응답시간을 함께 검증한
+
+**읽기 경로 최적화 사례**로 정리할 수 있다.

--- a/docs/product-search-after-analysis.md
+++ b/docs/product-search-after-analysis.md
@@ -1,0 +1,281 @@
+# Product Search After Analysis
+
+## 목적
+
+Before 분석에서 확인한 상품 검색 병목 중 두 가지를 직접 개선해 보려 했다.
+
+- `LATEST`: `PRIMARY reverse scan`
+- `PRICE_ASC`: `table scan + sort`
+
+핵심 가설은 다음과 같았다.
+
+1. `LATEST`는 `category + state + id` 전용 인덱스를 추가하면 더 나은 실행계획을 탈 수 있다.
+2. `PRICE_ASC`는 이미 `(category, state, price, id)` 인덱스가 있음에도 optimizer가 content 조회에서 `table scan + sort`를 선택하므로,
+   쿼리 shape를 더 구체적으로 쪼개면 optimizer를 설득할 수 있다.
+
+## 시도한 구현
+
+### 1. 검색 경로 분리
+
+기존에는 `search()` 하나가 모든 정렬을 처리했다.
+
+이를 아래처럼 정렬별 전용 경로로 분리했다.
+
+- `searchLatest(...)`
+- `searchPriceAsc(...)`
+- `searchPriceDesc(...)`
+
+의도:
+
+- `LATEST`, `PRICE_ASC`, `PRICE_DESC`가 같은 검색 API 안에 있더라도
+  DB 관점에서는 서로 다른 실행 전략을 가질 수 있게 만들기 위함
+
+### 2. LATEST 전용 인덱스 추가
+
+추가했던 인덱스:
+
+```sql
+CREATE INDEX idx_products_category_state_id
+    ON products (category, state, id);
+```
+
+의도:
+
+- `WHERE category = ? AND state = ? ORDER BY id DESC LIMIT ?`
+  패턴에 대해 optimizer가 `PRIMARY reverse scan` 대신
+  `category + state + id` 전용 인덱스를 선택하도록 유도
+
+### 3. PRICE_ASC 2단계 조회
+
+`PRICE_ASC`는 다음 구조로 바꿨다.
+
+1. 인덱스를 활용해 `id`만 먼저 조회
+2. 그 `id`들로 실제 본문 컬럼을 다시 조회
+
+개념은 아래와 같았다.
+
+```text
+1차 조회: category + state + price range + order by price asc + limit -> id 20개
+2차 조회: id in (...) -> name, imageUrl, price, seller 정보 조회
+```
+
+의도:
+
+- 기존에는 content 조회에서 비인덱스 컬럼까지 한 번에 읽으려다 optimizer가 `table scan + sort`를 선택했다.
+- 먼저 `id`만 좁히면 `(category, state, price, id)` 인덱스를 더 명확하게 탈 수 있다고 판단했다.
+
+## 측정 결과
+
+After 기준 run:
+
+- `1775994364`
+- `1775995228`
+
+이 중 `1775995228`은 `LATEST` 인덱스 실험을 되돌리고 `PRICE_ASC` 2단계 조회만 남긴 상태의 결과다.
+
+### 기준 Before
+
+- `LATEST`
+  - avg `217.94ms`
+  - p95 `384.37ms`
+- `PRICE_ASC`
+  - avg `125.41ms`
+  - p95 `212.66ms`
+- `PRICE_DESC`
+  - avg `111.95ms`
+  - p95 `188.74ms`
+
+### LATEST 인덱스 추가 시도 결과
+
+관찰:
+
+- content 조회는 여전히 `PRIMARY reverse scan`
+- count만 새 인덱스를 사용
+- 그리고 새 인덱스가 `PRICE_ASC`, `PRICE_DESC` 실행계획까지 오염시켰다
+
+결론:
+
+- `LATEST`용으로 추가한 인덱스가 핵심 content 조회를 충분히 개선하지 못했다
+- 반대로 price 계열 경로에서 optimizer가 기존 `price` 인덱스 대신
+  새 인덱스를 고르는 부작용을 만들었다
+
+즉 `LATEST` 전용 인덱스 추가는 실패한 접근이었다.
+
+### PRICE_ASC 2단계 조회 결과
+
+최종적으로 `LATEST` 인덱스 실험을 제거한 뒤 측정한 결과:
+
+- `PRICE_ASC`
+  - Before avg `125.41ms`
+  - After avg `128.37ms`
+  - Before p95 `212.66ms`
+  - After p95 `218.96ms`
+
+즉 `PRICE_ASC`는 오히려 소폭 악화됐다.
+
+## 왜 실패했는가
+
+### 1. LATEST 인덱스 추가는 "한 쿼리 최적화"가 아니라 "다른 쿼리 오염"을 만들었다
+
+추가한 `(category, state, id)` 인덱스는
+`LATEST`를 위해 넣었지만, optimizer는 이를 `PRICE_ASC`, `PRICE_DESC` 경로의 count/content에도 활용하려고 시도했다.
+
+즉 인덱스 하나를 추가하면 해당 쿼리만 좋아지는 것이 아니라,
+같은 테이블을 쓰는 다른 쿼리의 실행계획까지 바뀔 수 있다는 점을 직접 확인했다.
+
+### 2. PRICE_ASC는 content만 최적화해선 부족했다
+
+2단계 조회 구조는 content 조회를 인덱스 친화적으로 만들려는 시도였다.
+하지만 실제 API 전체 비용은 아래처럼 계산됐다.
+
+- 기존:
+  - content 조회 1회
+  - count 1회
+- 변경 후:
+  - count 1회
+  - id 선조회 1회
+  - 본문 조회 1회
+
+즉 `table scan + sort`를 줄이는 대신 DB 왕복이 한 번 늘었다.
+
+현재 데이터 분포와 단일 서버 환경에서는,
+기존 `PRICE_ASC`의 병목이 생각보다 치명적이지 않았고
+추가된 쿼리 비용이 그 이득을 상쇄했다.
+
+### 3. 진짜 병목 단위는 content만이 아니라 content + count 전체였다
+
+처음에는 `PRICE_ASC` content 조회의 `table scan + sort`에 집중했다.
+하지만 실제로는 `Page` 기반 검색이라 count 비용도 항상 포함된다.
+
+즉 content만 최적화한다고 전체 API가 빨라지지 않는다는 사실을 확인했다.
+
+## 배운 점
+
+### 1. "인덱스가 있으니 그 인덱스를 타게 만들면 된다"는 단순한 문제가 아니었다
+
+실제로는:
+
+- 데이터 분포
+- selection
+- count 존재 여부
+- row lookup 비용
+- 쿼리 횟수 증가
+
+까지 모두 합쳐서 전체 비용을 봐야 했다.
+
+### 2. 인덱스 추가는 국소 최적화가 아니라 실행계획 전체를 흔드는 작업이다
+
+`LATEST` 전용 인덱스를 추가했을 때,
+원래 타던 `price` 인덱스까지 optimizer가 덜 쓰게 되는 부작용을 겪었다.
+
+즉 새 인덱스는 "좋아질 쿼리"만 보는 게 아니라
+"같은 테이블을 쓰는 다른 핵심 쿼리까지 어떻게 바꿀지"를 같이 봐야 한다.
+
+### 3. Query shape를 쪼개는 것만으로는 충분하지 않을 수 있다
+
+`PRICE_ASC`는 분명히 더 구체적인 구조로 쪼갰다.
+하지만 count를 그대로 둔 상태에선 전체 API 비용이 개선되지 않았다.
+
+즉 실제 최적화는:
+
+- content
+- count
+- round trip 수
+- 페이지네이션 방식
+
+전체를 같이 봐야 한다.
+
+### 4. "문제를 발견하고 버릴 수 있는 것"도 실력이다
+
+이번 시도는 최종 성능 개선으로 이어지지 않았다.
+하지만 다음 두 가지를 명확히 확인했다.
+
+1. `LATEST` 인덱스 추가는 현재 구조에선 부작용이 더 크다
+2. `PRICE_ASC`는 count까지 포함해 다시 설계하지 않으면 개선이 어렵다
+
+즉 결과가 안 좋을 때도 억지로 밀어붙이지 않고,
+측정 결과에 따라 가설을 폐기하는 판단이 필요하다는 점을 배웠다.
+
+### 5. 인덱스만으로는 탐색형 검색 최적화에 한계가 있다
+
+이번 시도를 통해 가장 크게 배운 점은
+"탐색형 검색은 인덱스만 잘 설계하면 해결된다"는 생각이 틀릴 수 있다는 점이다.
+
+실제 API 비용은 인덱스 하나로 결정되지 않는다.
+
+- `WHERE` 선택도
+- `ORDER BY`
+- `LIMIT / OFFSET`
+- `COUNT(*)`
+- projection 컬럼 수
+- 쿼리 횟수
+- 데이터 분포
+
+이 요소들이 함께 전체 비용을 만든다.
+
+즉 인덱스는 중요한 수단이지만,
+검색 API 전체 구조를 대신 해결해주지는 못한다.
+
+### 6. 옵티마이저를 유도하는 것도 중요하지만, 그 전에 병목 단위를 정확히 잡아야 한다
+
+이번 시도에서는 "optimizer가 `PRICE_ASC`에서 인덱스를 타게 만들자"는 접근으로 시작했다.
+그 자체는 타당한 문제의식이었다.
+
+하지만 실제로는 `PRICE_ASC`의 병목이
+content 조회 하나가 아니라
+`content + count + pagination 비용` 전체였기 때문에,
+optimizer 유도만으로는 충분하지 않았다.
+
+즉 튜닝은 단순히 "실행계획을 원하는 모양으로 바꾸는 것"이 아니라,
+"사용자 요청 하나를 처리하는 전체 비용 구조를 바꾸는 것"이라는 점을 확인했다.
+
+## 남은 가능성
+
+이번 시도로는 최종 개선을 만들지 못했지만, 다음 후보는 남아 있다.
+
+### 1. `Page -> Slice`
+
+현재 `PRICE_ASC`는 `Page` 기반이라 항상 `count(*)`가 따라붙는다.
+그래서 2단계 조회를 해도 전체 API 비용이 잘 줄지 않았다.
+
+`Slice`로 바꾸면 count를 제거할 수 있고,
+그때는 2단계 조회의 이득이 실제로 드러날 가능성이 있다.
+
+다만 이 경우 주제는
+"ASC 인덱스 최적화"보다는
+"탐색형 조회의 페이지네이션 비용 최적화"에 가까워진다.
+
+### 2. Keyset pagination
+
+특히 `LATEST`, `PRICE_ASC`처럼 정렬 중심 탐색은
+깊은 페이지로 갈수록 `OFFSET` 비용이 커질 수 있다.
+
+이 경우 keyset pagination이 더 적합할 수 있다.
+
+하지만 API 계약이 바뀌므로,
+이번 이력서 불릿 강화 목적과는 주제가 달라진다.
+
+### 3. 검색용 read model 또는 별도 검색 구조
+
+탐색형 검색이 더 복잡해지면
+RDB 단일 테이블 인덱스만으로 끝까지 해결하려고 하기보다,
+검색용 projection table이나 별도 검색 구조를 고민하는 것이 더 맞을 수 있다.
+
+즉 지금의 실패는 "검색 최적화가 불가능하다"는 뜻이 아니라,
+"이번 문제는 인덱스와 Querydsl 수준보다 더 상위의 조회 전략 문제"였다는 뜻에 가깝다.
+
+## 최종 결론
+
+이번 상품 검색 튜닝 시도는 Before 분석은 유의미했지만,
+After에서 핵심 가설을 입증하지 못했다.
+
+- `LATEST` 인덱스 추가는 다른 검색 경로의 optimizer 선택을 오염시켰다.
+- `PRICE_ASC` 2단계 조회는 count 비용이 남아 있어 전체 성능 개선으로 이어지지 않았다.
+
+따라서 이 변경은 서비스 코드에 남기지 않고 원복했으며,
+문제 분석과 실패 원인을 학습 자산으로만 보존했다.
+
+## 한 줄 요약
+
+`PRICE_ASC`의 `table scan + sort`를 보고 쿼리 shape를 더 구체적으로 쪼개 optimizer를 설득하려 했지만,
+현재 환경에서는 줄인 비용보다 늘어난 쿼리 비용이 더 커서 개선이 나오지 않았다.

--- a/docs/product-search-before-analysis.md
+++ b/docs/product-search-before-analysis.md
@@ -1,0 +1,236 @@
+# Product Search Before Analysis
+
+## 목적
+
+상품 검색 API의 조회 성능을 `Querydsl + 복합 인덱스 + 실행계획` 관점에서 개선하기 전에,
+현재 병목이 어디에 있는지 계측으로 먼저 고정한다.
+
+이번 Before 분석의 대상은 `keyword` 없는 탐색형 검색이다.
+
+## 기준 코드
+
+- 검색 구현: `product-service/src/main/java/com/thock/back/product/out/ProductRepositoryImpl.java`
+- 검색 인덱스: `product-service/src/main/resources/db/migration/V7__add_product_search_indexes.sql`
+
+현재 검색 정렬은 다음 셋뿐이다.
+
+- `LATEST -> ORDER BY id DESC`
+- `PRICE_ASC -> ORDER BY price ASC`
+- `PRICE_DESC -> ORDER BY price DESC`
+
+현재 products 테이블 인덱스는 다음 두 개다.
+
+- `PRIMARY (id)`
+- `idx_products_category_state_price_id (category, state, price, id)`
+
+즉 현재 구조는 `search()` 하나와 복합 인덱스 하나로
+`LATEST`, `PRICE_ASC`, `PRICE_DESC`, `COUNT`를 모두 처리하려는 범용 구조다.
+
+## Before 실험 환경
+
+- run_id: `1775974311`
+- 데이터 건수: `100,000`
+- 상태 분포:
+  - `ON_SALE 75,000`
+  - `SOLD_OUT 15,000`
+  - `STOPPED 10,000`
+- category: `KEYBOARD`
+- 부하 조건:
+  - `K6_ITERATIONS=3000`
+  - `K6_VUS=50`
+
+근거 파일:
+
+- `loadtest/results/product-search-dataset-1775974311.json`
+- `loadtest/results/product-search-latest-1775974311.json`
+- `loadtest/results/product-search-price-asc-1775974311.json`
+- `loadtest/results/product-search-price-desc-1775974311.json`
+- `loadtest/results/product-search-latest-explain-1775974311.txt`
+- `loadtest/results/product-search-price-asc-explain-1775974311.txt`
+- `loadtest/results/product-search-price-desc-explain-1775974311.txt`
+
+## 실제 쿼리 Shape
+
+### 1. LATEST
+
+```sql
+SELECT ...
+FROM products
+WHERE category = 'KEYBOARD'
+  AND state = 'ON_SALE'
+ORDER BY id DESC
+LIMIT 20 OFFSET 0;
+
+SELECT COUNT(*)
+FROM products
+WHERE category = 'KEYBOARD'
+  AND state = 'ON_SALE';
+```
+
+### 2. PRICE_ASC
+
+```sql
+SELECT ...
+FROM products
+WHERE category = 'KEYBOARD'
+  AND state = 'ON_SALE'
+  AND price BETWEEN 50000 AND 300000
+ORDER BY price ASC
+LIMIT 20 OFFSET 0;
+
+SELECT COUNT(*)
+FROM products
+WHERE category = 'KEYBOARD'
+  AND state = 'ON_SALE'
+  AND price BETWEEN 50000 AND 300000;
+```
+
+### 3. PRICE_DESC
+
+```sql
+SELECT ...
+FROM products
+WHERE category = 'KEYBOARD'
+  AND state = 'ON_SALE'
+  AND price BETWEEN 50000 AND 300000
+ORDER BY price DESC
+LIMIT 20 OFFSET 0;
+
+SELECT COUNT(*)
+FROM products
+WHERE category = 'KEYBOARD'
+  AND state = 'ON_SALE'
+  AND price BETWEEN 50000 AND 300000;
+```
+
+## Before 결과
+
+### 응답시간
+
+- `LATEST`
+  - avg `217.94ms`
+  - p95 `384.37ms`
+- `PRICE_ASC`
+  - avg `125.41ms`
+  - p95 `212.66ms`
+- `PRICE_DESC`
+  - avg `111.95ms`
+  - p95 `188.74ms`
+
+### 실행계획 핵심 요약
+
+#### LATEST
+
+- content 조회: `PRIMARY reverse scan`
+- count 조회: `idx_products_category_state_price_id` 사용
+
+해석:
+
+- 현재 복합 인덱스는 `latest(id desc)` 전용 인덱스가 아니다.
+- 그래서 optimizer는 검색용 복합 인덱스보다 `PRIMARY reverse scan`을 택했다.
+
+#### PRICE_ASC
+
+- content 조회: `table scan + sort`
+- count 조회: `idx_products_category_state_price_id` range scan
+
+해석:
+
+- `price`가 인덱스에 포함돼 있어도 content 조회 전체 비용이 충분히 싸다고 optimizer가 보지 않았다.
+- 현재 데이터 분포상:
+  - 전체 `100,000`
+  - `ON_SALE 75,000`
+  - `price between 50000 and 300000` 이후 `38,308`
+- 즉 선두 조건 선택도가 낮고, content 조회는 covering index도 아니다.
+- 그래서 optimizer는 `index range scan + row lookup`보다 `table scan + sort`가 더 싸다고 판단했다.
+
+#### PRICE_DESC
+
+- content 조회: `idx_products_category_state_price_id reverse range scan`
+- count 조회: `idx_products_category_state_price_id` range scan
+
+해석:
+
+- 현재 인덱스를 역방향으로 읽는 경로가 optimizer에게 더 싸게 보였다.
+- 이것은 `DESC용으로 잘못 설계했다`는 뜻이 아니라,
+  현재 cost model에서 `DESC` 경로만 상대적으로 인덱스를 탈 만하다고 본 것이다.
+
+## 핵심 문제 정리
+
+현재 문제는 인덱스가 전혀 없는 것이 아니다.
+
+문제는 다음 두 가지다.
+
+1. `search()` 하나가 `LATEST`, `PRICE_ASC`, `PRICE_DESC`, `COUNT`를 모두 처리하는 범용 구조다.
+2. 인덱스도 `(category, state, price, id)` 하나로 여러 정렬 패턴을 동시에 만족시키려 한다.
+
+즉 코드상으로는 동적 쿼리이지만, DB 관점에서는 여전히 하나의 범용 검색 파이프라인이다.
+
+이 구조에서는 각 검색이 원하는 정렬 축이 다름에도,
+optimizer가 모든 경우에 현재 인덱스를 "가장 싼 경로"라고 보지 않는다.
+
+## 중요한 학습 포인트
+
+### 1. 컬럼이 인덱스에 있다고 해서 정렬 최적화가 보장되지는 않는다
+
+`price ASC`가 현재 인덱스에 포함돼 있어도,
+optimizer는 전체 비용이 더 싸지 않다고 보면 index scan 대신 table scan + sort를 선택할 수 있다.
+
+### 2. 동적 쿼리와 쿼리 분리는 다른 문제다
+
+현재도 조건에 따라 SQL은 달라지지만,
+실제로는 하나의 공통 `search()` 메서드와 공통 `count` 전략을 사용한다.
+
+튜닝 관점에서의 "분리"는 단순 if문이 아니라,
+정렬/용도별로 다른 SQL shape, 다른 count 전략, 다른 인덱스 전략을 허용하는 것이다.
+
+### 3. 오설계의 본질은 "DESC를 빠르게 만든 것"이 아니다
+
+현재 문제는 `DESC`가 잘 되는 오설계가 아니라,
+`LATEST`와 `PRICE_ASC`가 optimizer가 신뢰할 만한 전용 경로를 갖지 못했다는 점이다.
+
+## 다음 튜닝 방향
+
+### 1. 탐색형 검색을 정렬별로 분리
+
+- `searchLatest(...)`
+- `searchPriceAsc(...)`
+- `searchPriceDesc(...)`
+
+`keyword` 검색은 현재 단계에서 튜닝 대상에서 제외하거나 fallback 경로로 유지한다.
+
+### 2. 인덱스를 목적별로 분리
+
+검토 후보:
+
+- `LATEST` 전용 인덱스: `(category, state, id)`
+- `PRICE` 전용 인덱스: `(category, state, price, id)` 유지 또는 조정
+
+### 3. PRICE_ASC는 필요하면 2단계 조회로 전환
+
+예시 방향:
+
+1. 인덱스로 `id`만 20개 선조회
+2. 그 20개 `id`로 실제 컬럼 fetch
+
+목적:
+
+- optimizer가 인덱스 기반 limit 경로를 자연스럽게 고르도록 SQL shape를 더 명확하게 만든다.
+
+### 4. count 전략 재검토
+
+현재는 모든 탐색 검색이 `Page + count(*)`를 유지한다.
+
+검토 대상:
+
+- `Slice` 전환
+- count 조건부 실행
+- content 조회와 count 전략 분리
+
+## 한 줄 결론
+
+현재 상품 검색 문제는 "인덱스가 없다"가 아니라,
+"하나의 범용 검색 경로와 하나의 범용 인덱스로 여러 정렬 패턴을 동시에 만족시키려다 보니 optimizer가 일부 경로를 신뢰하지 못하는 구조"다.
+
+따라서 다음 단계는 탐색형 검색을 정렬별로 분리하고,
+그에 맞는 전용 인덱스와 조회 전략으로 optimizer가 자연스럽게 인덱스를 선택하게 만드는 것이다.

--- a/loadtest/order-query-read.js
+++ b/loadtest/order-query-read.js
@@ -1,0 +1,115 @@
+import http from 'k6/http';
+import { check, fail } from 'k6';
+
+const experimentName = __ENV.EXPERIMENT_NAME || 'order-query-read';
+const summaryPath = __ENV.SUMMARY_PATH || `/results/${experimentName}.json`;
+const mode = (__ENV.ORDER_QUERY_MODE || 'optimized').toLowerCase();
+const baseUrl = (__ENV.MARKET_SERVICE_BASE_URL || 'http://market-service:8083').replace(/\/$/, '');
+const memberId = parsePositiveInteger(__ENV.ORDER_QUERY_MEMBER_ID, 999001);
+const orderCount = parsePositiveInteger(__ENV.ORDER_QUERY_ORDER_COUNT, 100);
+const itemsPerOrder = parsePositiveInteger(__ENV.ORDER_QUERY_ITEMS_PER_ORDER, 5);
+const iterations = parsePositiveInteger(__ENV.ITERATIONS, 300);
+const vus = parsePositiveInteger(__ENV.VUS, 20);
+
+export const options = {
+  scenarios: {
+    order_query_read: {
+      executor: 'shared-iterations',
+      vus,
+      iterations,
+      maxDuration: __ENV.MAX_DURATION || '3m',
+    },
+  },
+};
+
+export function setup() {
+  resetDataset();
+
+  const seedResponse = http.post(
+    `${baseUrl}/api/v1/experiments/order-query/dataset/seed`,
+    JSON.stringify({
+      memberId,
+      orderCount,
+      itemsPerOrder,
+    }),
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      tags: {
+        name: 'order_query_seed',
+      },
+    }
+  );
+
+  if (!check(seedResponse, {
+    'seed status is 200': (response) => response.status === 200,
+  })) {
+    fail(`seed failed: status=${seedResponse.status} body=${seedResponse.body}`);
+  }
+
+  const dataset = seedResponse.json();
+
+  if (!dataset || dataset.orderCount !== orderCount) {
+    fail(`unexpected dataset response: ${seedResponse.body}`);
+  }
+
+  return {
+    baseUrl,
+    mode,
+    memberId: dataset.memberId,
+    expectedOrderCount: dataset.orderCount,
+  };
+}
+
+export default function (data) {
+  const response = http.get(
+    `${data.baseUrl}/api/v1/experiments/order-query/${data.mode}/${data.memberId}`,
+    {
+      tags: {
+        name: `order_query_${data.mode}`,
+      },
+    }
+  );
+
+  let payloadLength = -1;
+  try {
+    payloadLength = response.json().length;
+  } catch (error) {
+    payloadLength = -1;
+  }
+
+  check(response, {
+    'status is 200': (res) => res.status === 200,
+    'order count matches dataset': () => payloadLength === data.expectedOrderCount,
+  });
+}
+
+export function handleSummary(data) {
+  return {
+    [summaryPath]: JSON.stringify(data, null, 2),
+  };
+}
+
+function resetDataset() {
+  const resetResponse = http.post(`${baseUrl}/api/v1/experiments/order-query/dataset/reset?memberId=${memberId}`, null, {
+    tags: {
+      name: 'order_query_reset',
+    },
+  });
+
+  if (!check(resetResponse, {
+    'reset status is 200': (response) => response.status === 200,
+  })) {
+    fail(`reset failed: status=${resetResponse.status} body=${resetResponse.body}`);
+  }
+}
+
+function parsePositiveInteger(rawValue, defaultValue) {
+  const parsed = Number(rawValue || defaultValue);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return defaultValue;
+  }
+
+  return Math.floor(parsed);
+}

--- a/loadtest/run-order-query-experiment.sh
+++ b/loadtest/run-order-query-experiment.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+RUN_ID="${RUN_ID:-$(date +%s)}"
+MARKET_SERVICE_BASE_URL="${MARKET_SERVICE_BASE_URL:-http://market-service:8083}"
+MARKET_SERVICE_HEALTH_URL="${MARKET_SERVICE_HEALTH_URL:-${MARKET_SERVICE_BASE_URL}/actuator/health}"
+WAIT_MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS:-40}"
+WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS:-2}"
+WAIT_STABLE_SUCCESSES="${WAIT_STABLE_SUCCESSES:-3}"
+ORDER_COUNT="${ORDER_QUERY_ORDER_COUNT:-100}"
+ITEMS_PER_ORDER="${ORDER_QUERY_ITEMS_PER_ORDER:-5}"
+ITERATIONS="${K6_ITERATIONS:-300}"
+VUS="${K6_VUS:-20}"
+
+wait_for_market_service() {
+  docker compose --profile loadtest run --no-deps --rm \
+    -e WAIT_URL="${MARKET_SERVICE_HEALTH_URL}" \
+    -e WAIT_MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS}" \
+    -e WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS}" \
+    -e WAIT_STABLE_SUCCESSES="${WAIT_STABLE_SUCCESSES}" \
+    k6 run /scripts/wait-http.js
+}
+
+docker compose up -d mysql redpanda product-service payment-service
+
+MARKET_SERVICE_PROFILES_ACTIVE=docker,experiment \
+docker compose up -d --build market-service
+
+wait_for_market_service
+
+for mode in baseline optimized; do
+  experiment_name="order-query-${mode}"
+  summary_path="/results/${experiment_name}-${RUN_ID}.json"
+
+  cat <<EOF
+experiment=${experiment_name}
+run_id=${RUN_ID}
+order_count=${ORDER_COUNT}
+items_per_order=${ITEMS_PER_ORDER}
+iterations=${ITERATIONS}
+vus=${VUS}
+summary_path=${summary_path}
+EOF
+
+  docker compose --profile loadtest run --no-deps --rm \
+    -e RUN_ID="${RUN_ID}" \
+    -e EXPERIMENT_NAME="${experiment_name}" \
+    -e SUMMARY_PATH="${summary_path}" \
+    -e MARKET_SERVICE_BASE_URL="${MARKET_SERVICE_BASE_URL}" \
+    -e ORDER_QUERY_MODE="${mode}" \
+    -e ORDER_QUERY_ORDER_COUNT="${ORDER_COUNT}" \
+    -e ORDER_QUERY_ITEMS_PER_ORDER="${ITEMS_PER_ORDER}" \
+    -e ITERATIONS="${ITERATIONS}" \
+    -e VUS="${VUS}" \
+    -e MAX_DURATION="${K6_MAX_DURATION:-3m}" \
+    k6 run /scripts/order-query-read.js
+done
+
+cat <<EOF
+result_prefix=loadtest/results/order-query
+run_id=${RUN_ID}
+order_count=${ORDER_COUNT}
+items_per_order=${ITEMS_PER_ORDER}
+EOF

--- a/market-service/src/main/java/com/thock/back/market/app/OrderService.java
+++ b/market-service/src/main/java/com/thock/back/market/app/OrderService.java
@@ -24,7 +24,7 @@ public class OrderService {
      */
     @Transactional(readOnly = true)
     public List<OrderDetailResponse> getMyOrders(Long memberId) {
-        List<Order> orders = orderRepository.findByBuyerIdOrderByCreatedAtDesc(memberId);
+        List<Order> orders = orderRepository.findDetailsByBuyerIdOrderByCreatedAtDesc(memberId);
 
         return orders.stream()
                 .map(OrderDetailResponse::from)
@@ -36,7 +36,7 @@ public class OrderService {
      */
     @Transactional(readOnly = true)
     public OrderDetailResponse getOrderDetail(Long memberId, Long orderId) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.findDetailById(orderId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
         // 본인 주문인지 확인

--- a/market-service/src/main/java/com/thock/back/market/experiment/OrderQueryExperimentController.java
+++ b/market-service/src/main/java/com/thock/back/market/experiment/OrderQueryExperimentController.java
@@ -1,0 +1,58 @@
+package com.thock.back.market.experiment;
+
+import com.thock.back.market.in.dto.res.OrderDetailResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Profile("experiment")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/experiments/order-query")
+public class OrderQueryExperimentController {
+
+    private final OrderQueryExperimentService orderQueryExperimentService;
+
+    @PostMapping("/dataset/reset")
+    public ResponseEntity<OrderQueryExperimentDatasetResponse> resetDataset(
+            @RequestParam(required = false) Long memberId
+    ) {
+        return ResponseEntity.ok(orderQueryExperimentService.resetDataset(memberId));
+    }
+
+    @PostMapping("/dataset/seed")
+    public ResponseEntity<OrderQueryExperimentDatasetResponse> seedDataset(
+            @RequestBody(required = false) OrderQueryExperimentSeedRequest request
+    ) {
+        return ResponseEntity.ok(orderQueryExperimentService.seedDataset(request));
+    }
+
+    @GetMapping("/dataset")
+    public ResponseEntity<OrderQueryExperimentDatasetResponse> getDataset(
+            @RequestParam(required = false) Long memberId
+    ) {
+        return ResponseEntity.ok(orderQueryExperimentService.getDataset(memberId));
+    }
+
+    @GetMapping("/baseline/{memberId}")
+    public ResponseEntity<List<OrderDetailResponse>> getBaselineOrders(
+            @PathVariable Long memberId
+    ) {
+        return ResponseEntity.ok(orderQueryExperimentService.getMyOrdersBaseline(memberId));
+    }
+
+    @GetMapping("/optimized/{memberId}")
+    public ResponseEntity<List<OrderDetailResponse>> getOptimizedOrders(
+            @PathVariable Long memberId
+    ) {
+        return ResponseEntity.ok(orderQueryExperimentService.getMyOrdersOptimized(memberId));
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/experiment/OrderQueryExperimentDatasetResponse.java
+++ b/market-service/src/main/java/com/thock/back/market/experiment/OrderQueryExperimentDatasetResponse.java
@@ -1,0 +1,8 @@
+package com.thock.back.market.experiment;
+
+public record OrderQueryExperimentDatasetResponse(
+        Long memberId,
+        int orderCount,
+        int itemCount
+) {
+}

--- a/market-service/src/main/java/com/thock/back/market/experiment/OrderQueryExperimentSeedRequest.java
+++ b/market-service/src/main/java/com/thock/back/market/experiment/OrderQueryExperimentSeedRequest.java
@@ -1,0 +1,8 @@
+package com.thock.back.market.experiment;
+
+public record OrderQueryExperimentSeedRequest(
+        Long memberId,
+        Integer orderCount,
+        Integer itemsPerOrder
+) {
+}

--- a/market-service/src/main/java/com/thock/back/market/experiment/OrderQueryExperimentService.java
+++ b/market-service/src/main/java/com/thock/back/market/experiment/OrderQueryExperimentService.java
@@ -1,0 +1,134 @@
+package com.thock.back.market.experiment;
+
+import com.thock.back.market.app.OrderService;
+import com.thock.back.market.domain.MarketMember;
+import com.thock.back.market.domain.Order;
+import com.thock.back.market.in.dto.res.OrderDetailResponse;
+import com.thock.back.market.out.repository.MarketMemberRepository;
+import com.thock.back.market.out.repository.OrderRepository;
+import com.thock.back.shared.member.domain.MemberRole;
+import com.thock.back.shared.member.domain.MemberState;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Profile("experiment")
+@RequiredArgsConstructor
+public class OrderQueryExperimentService {
+
+    private static final long DEFAULT_MEMBER_ID = 999_001L;
+    private static final int DEFAULT_ORDER_COUNT = 100;
+    private static final int DEFAULT_ITEMS_PER_ORDER = 5;
+    private static final long DEFAULT_SELLER_ID = 10L;
+
+    private final OrderRepository orderRepository;
+    private final MarketMemberRepository marketMemberRepository;
+    private final OrderService orderService;
+
+    @Transactional
+    public OrderQueryExperimentDatasetResponse resetDataset(Long memberId) {
+        Long resolvedMemberId = resolveMemberId(memberId);
+        ensureExperimentMember(resolvedMemberId);
+
+        List<Order> orders = orderRepository.findByBuyerIdOrderByCreatedAtDesc(resolvedMemberId);
+        if (!orders.isEmpty()) {
+            orderRepository.deleteAll(orders);
+            orderRepository.flush();
+        }
+
+        return new OrderQueryExperimentDatasetResponse(resolvedMemberId, 0, 0);
+    }
+
+    @Transactional
+    public OrderQueryExperimentDatasetResponse seedDataset(OrderQueryExperimentSeedRequest request) {
+        Long memberId = resolveMemberId(request == null ? null : request.memberId());
+        int orderCount = positiveOrDefault(request == null ? null : request.orderCount(), DEFAULT_ORDER_COUNT);
+        int itemsPerOrder = positiveOrDefault(request == null ? null : request.itemsPerOrder(), DEFAULT_ITEMS_PER_ORDER);
+
+        resetDataset(memberId);
+        MarketMember buyer = ensureExperimentMember(memberId);
+
+        List<Order> orders = new ArrayList<>(orderCount);
+        for (int orderIndex = 0; orderIndex < orderCount; orderIndex++) {
+            Order order = new Order(
+                    buyer,
+                    "06234",
+                    "서울시 강남구 테헤란로 123",
+                    "101호"
+            );
+
+            for (int itemIndex = 0; itemIndex < itemsPerOrder; itemIndex++) {
+                long productSequence = ((long) orderIndex * itemsPerOrder) + itemIndex + 1L;
+                long price = 10_000L + (itemIndex * 1_000L);
+                long salePrice = price - 1_000L;
+
+                order.addItem(
+                        DEFAULT_SELLER_ID,
+                        1_000L + productSequence,
+                        "order-query-product-" + productSequence,
+                        "https://example.com/images/" + productSequence + ".png",
+                        price,
+                        salePrice,
+                        1
+                );
+            }
+
+            orders.add(order);
+        }
+
+        orderRepository.saveAll(orders);
+        orderRepository.flush();
+
+        return new OrderQueryExperimentDatasetResponse(memberId, orderCount, orderCount * itemsPerOrder);
+    }
+
+    @Transactional(readOnly = true)
+    public OrderQueryExperimentDatasetResponse getDataset(Long memberId) {
+        Long resolvedMemberId = resolveMemberId(memberId);
+        List<Order> orders = orderRepository.findDetailsByBuyerIdOrderByCreatedAtDesc(resolvedMemberId);
+        int itemCount = orders.stream()
+                .mapToInt(order -> order.getItems().size())
+                .sum();
+
+        return new OrderQueryExperimentDatasetResponse(resolvedMemberId, orders.size(), itemCount);
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrderDetailResponse> getMyOrdersBaseline(Long memberId) {
+        Long resolvedMemberId = resolveMemberId(memberId);
+        return orderRepository.findByBuyerIdOrderByCreatedAtDesc(resolvedMemberId).stream()
+                .map(OrderDetailResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrderDetailResponse> getMyOrdersOptimized(Long memberId) {
+        return orderService.getMyOrders(resolveMemberId(memberId));
+    }
+
+    private MarketMember ensureExperimentMember(Long memberId) {
+        return marketMemberRepository.findById(memberId)
+                .orElseGet(() -> marketMemberRepository.save(new MarketMember(
+                        "order-query-experiment-" + memberId + "@example.com",
+                        "order-query-experiment-" + memberId,
+                        MemberRole.USER,
+                        MemberState.ACTIVE,
+                        memberId,
+                        LocalDateTime.now(),
+                        LocalDateTime.now()
+                )));
+    }
+
+    private Long resolveMemberId(Long memberId) {
+        return memberId == null ? DEFAULT_MEMBER_ID : memberId;
+    }
+
+    private int positiveOrDefault(Integer value, int defaultValue) {
+        return value == null || value <= 0 ? defaultValue : value;
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/out/repository/OrderRepository.java
+++ b/market-service/src/main/java/com/thock/back/market/out/repository/OrderRepository.java
@@ -2,7 +2,9 @@ package com.thock.back.market.out.repository;
 
 import com.thock.back.market.domain.Order;
 import com.thock.back.market.domain.OrderState;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -11,6 +13,24 @@ import java.util.Optional;
 public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByOrderNumber(String orderName);
     List<Order> findByBuyerIdOrderByCreatedAtDesc(Long buyerId);
+
+    @Query("""
+            select distinct o
+            from Order o
+            left join fetch o.items
+            where o.buyer.id = :buyerId
+            order by o.createdAt desc
+            """)
+    List<Order> findDetailsByBuyerIdOrderByCreatedAtDesc(@Param("buyerId") Long buyerId);
+
+    @Query("""
+            select distinct o
+            from Order o
+            left join fetch o.items
+            where o.id = :orderId
+            """)
+    Optional<Order> findDetailById(@Param("orderId") Long orderId);
+
     // 타임아웃 스케줄러용: 결제 요청 후 N분 경과한 미결제 주문 조회
     List<Order> findByStateAndRequestPaymentDateBefore(OrderState state, LocalDateTime before);
 

--- a/market-service/src/main/resources/application-experiment.yml
+++ b/market-service/src/main/resources/application-experiment.yml
@@ -1,0 +1,8 @@
+spring:
+  task:
+    scheduling:
+      enabled: false
+
+market:
+  metrics:
+    enabled: false

--- a/market-service/src/main/resources/application-test.yml
+++ b/market-service/src/main/resources/application-test.yml
@@ -16,6 +16,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+    properties:
+      hibernate:
+        generate_statistics: true
 
   task:
     scheduling:

--- a/market-service/src/test/java/com/thock/back/market/app/OrderServiceQueryOptimizationTest.java
+++ b/market-service/src/test/java/com/thock/back/market/app/OrderServiceQueryOptimizationTest.java
@@ -1,0 +1,131 @@
+package com.thock.back.market.app;
+
+import com.thock.back.market.domain.MarketMember;
+import com.thock.back.market.domain.Order;
+import com.thock.back.market.domain.OrderState;
+import com.thock.back.market.in.dto.res.OrderDetailResponse;
+import com.thock.back.market.out.repository.MarketMemberRepository;
+import com.thock.back.market.out.repository.OrderRepository;
+import com.thock.back.shared.member.domain.MemberRole;
+import com.thock.back.shared.member.domain.MemberState;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class OrderServiceQueryOptimizationTest {
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private MarketMemberRepository marketMemberRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    private Statistics statistics;
+    private Long buyerId;
+    private Long orderId;
+
+    @BeforeEach
+    void setUp() {
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        statistics = sessionFactory.getStatistics();
+        statistics.clear();
+
+        MarketMember buyer = marketMemberRepository.save(new MarketMember(
+                "buyer@test.com",
+                "buyer",
+                MemberRole.USER,
+                MemberState.ACTIVE,
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        ));
+
+        for (int i = 0; i < 5; i++) {
+            Order order = new Order(buyer, "06234", "서울시 강남구", "101호");
+            order.addItem(10L, 100L + i, "상품-" + i + "-1", "https://image/" + i + "-1", 10000L, 9000L, 1);
+            order.addItem(10L, 200L + i, "상품-" + i + "-2", "https://image/" + i + "-2", 15000L, 12000L, 2);
+            orderRepository.save(order);
+        }
+
+        orderRepository.flush();
+        entityManager.clear();
+
+        buyerId = buyer.getId();
+        orderId = orderRepository.findByBuyerIdOrderByCreatedAtDesc(buyerId).get(0).getId();
+
+        statistics.clear();
+        entityManager.clear();
+    }
+
+    @Test
+    void getMyOrders_reducesQueriesComparedToLazyLoadingBaseline() {
+        long baselineQueryCount = baselineMyOrdersQueryCount();
+
+        statistics.clear();
+        entityManager.clear();
+
+        List<OrderDetailResponse> responses = orderService.getMyOrders(buyerId);
+        long optimizedQueryCount = statistics.getPrepareStatementCount();
+
+        assertThat(responses).hasSize(5);
+        assertThat(baselineQueryCount).isEqualTo(6);
+        assertThat(optimizedQueryCount).isEqualTo(1);
+    }
+
+    @Test
+    void getOrderDetail_fetchesItemsInSingleQuery() {
+        long baselineQueryCount = baselineOrderDetailQueryCount();
+
+        statistics.clear();
+        entityManager.clear();
+
+        OrderDetailResponse response = orderService.getOrderDetail(buyerId, orderId);
+        long optimizedQueryCount = statistics.getPrepareStatementCount();
+
+        assertThat(response.items()).hasSize(2);
+        assertThat(baselineQueryCount).isEqualTo(2);
+        assertThat(optimizedQueryCount).isEqualTo(1);
+    }
+
+    private long baselineMyOrdersQueryCount() {
+        List<Order> orders = orderRepository.findByBuyerIdOrderByCreatedAtDesc(buyerId);
+        List<OrderDetailResponse> ignored = orders.stream()
+                .map(OrderDetailResponse::from)
+                .toList();
+
+        assertThat(ignored).hasSize(5);
+        return statistics.getPrepareStatementCount();
+    }
+
+    private long baselineOrderDetailQueryCount() {
+        Order order = orderRepository.findById(orderId).orElseThrow();
+        OrderDetailResponse ignored = OrderDetailResponse.from(order);
+
+        assertThat(ignored.items()).hasSize(2);
+        return statistics.getPrepareStatementCount();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #41 

## 변경 내용
- 주문 목록/상세 조회를 fetch join 전용 Repository 쿼리로 분리했습니다.
- OrderService가 fetch join 기반 조회 경로를 사용하도록 변경했습니다.
- Hibernate Statistics를 활용해 N+1 제거를 검증하는 테스트를 추가했습니다.
- market-service experiment profile과 주문 조회 baseline/optimized 비교 endpoint를 추가했습니다.
- k6 스크립트로 동일 데이터셋에서 주문 조회 응답시간을 비교할 수 있도록 했습니다.
- 주문 조회 JPA 최적화 및 기존 상품 검색 튜닝 회고 문서를 추가했습니다.

## 확인 내용
- Hibernate Statistics 기준 주문 목록 조회: N+1 -> 1쿼리
- Hibernate Statistics 기준 주문 상세 조회: 2 -> 1쿼리
- 주문 100건, 주문당 상품 5개 기준 3회 반복 부하 실험 중앙값:
  - avg 315.76ms -> 36.86ms (88.3% 감소)
  - p95 461.39ms -> 62.41ms (86.5% 감소)

## 테스트
- `./gradlew :market-service:compileJava`
- `./gradlew :market-service:test --tests com.thock.back.market.app.OrderServiceQueryOptimizationTest`
- `bash loadtest/run-order-query-experiment.sh`