### PR TITLE
[BUG] 배포용 Redis 설정 및 market-service Flyway 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,9 +185,8 @@ jobs:
             --exclude 'release-state.env' \
             --exclude 'logs/' \
             --exclude 'compose.sh' \
-            --exclude 'docker/' \
-            --exclude 'monitoring/' \
-            --exclude 'nginx/' \
+            --exclude 'nginx/ssl/' \
+            --exclude 'nginx/certbot/' \
             deploy-docker-compose/ \
             ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:~/deploy-docker-compose/
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,6 +163,11 @@ jobs:
       CHANGED_SERVICES: ${{ needs.detect-changes.outputs.services_space }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -172,6 +177,19 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Sync deploy compose files
+        run: |
+          rsync -az --delete \
+            --exclude '.env' \
+            --exclude 'release-state.env' \
+            --exclude 'logs/' \
+            --exclude 'compose.sh' \
+            --exclude 'docker/' \
+            --exclude 'monitoring/' \
+            --exclude 'nginx/' \
+            deploy-docker-compose/ \
+            ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:~/deploy-docker-compose/
 
       - name: Deploy to EC2 with Docker Compose
         run: |
@@ -243,6 +261,7 @@ jobs:
             done
 
             compose config >/dev/null
+            compose up -d mysql redpanda redis
             compose pull \$CHANGED_SERVICES
             compose up -d --no-deps \$CHANGED_SERVICES
 

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,29 @@ AWS EC2/deploy-kubernetes/base/secrets.yaml
 AWS EC2/deploy-kubernetes/ingress/ip-whitelist-middleware.yaml
 AWS EC2/deploy-docker-compose/nginx/ssl/*.key
 AWS EC2/deploy-docker-compose/nginx/ssl/*.crt
+/deploy-docker-compose/nginx/certbot/conf/live/api.thock.site/cert.pem
+/deploy-docker-compose/nginx/certbot/conf/archive/api.thock.site/cert1.pem
+/deploy-docker-compose/nginx/certbot/conf/live/api.thock.site/chain.pem
+/deploy-docker-compose/nginx/certbot/conf/archive/api.thock.site/chain1.pem
+/deploy-docker-compose/compose.sh
+/deploy-docker-compose/monitoring/grafana/provisioning/dashboards/dashboards.yml
+/deploy-docker-compose/monitoring/grafana/provisioning/datasources/datasources.yml
+/deploy-docker-compose/nginx/certbot/conf/live/api.thock.site/fullchain.pem
+/deploy-docker-compose/nginx/certbot/conf/archive/api.thock.site/fullchain1.pem
+/deploy-docker-compose/docker/init-databases.sql
+/deploy-docker-compose/monitoring/grafana/dashboards/logs-dashboard.json
+/deploy-docker-compose/monitoring/loki/loki-config.yml
+/deploy-docker-compose/nginx/certbot/conf/accounts/acme-v02.api.letsencrypt.org/directory/82a476c42ef082ba62e6594e0da38653/meta.json
+/deploy-docker-compose/nginx/nginx.conf
+/deploy-docker-compose/monitoring/grafana/dashboards/payment-service-dashboard.json
+/deploy-docker-compose/nginx/certbot/conf/accounts/acme-v02.api.letsencrypt.org/directory/82a476c42ef082ba62e6594e0da38653/private_key.json
+/deploy-docker-compose/nginx/certbot/conf/live/api.thock.site/privkey.pem
+/deploy-docker-compose/nginx/certbot/conf/archive/api.thock.site/privkey1.pem
+/deploy-docker-compose/monitoring/prometheus/prometheus.yml
+/deploy-docker-compose/monitoring/promtail/promtail-config.yml
+/deploy-docker-compose/nginx/certbot/conf/live/api.thock.site/README
+/deploy-docker-compose/nginx/certbot/conf/live/README
+/deploy-docker-compose/nginx/certbot/conf/accounts/acme-v02.api.letsencrypt.org/directory/82a476c42ef082ba62e6594e0da38653/regr.json
+/deploy-docker-compose/nginx/ssl/server.crt
+/deploy-docker-compose/nginx/ssl/server.key
+/deploy-docker-compose/monitoring/grafana/dashboards/spring-boot-overview.json

--- a/.gitignore
+++ b/.gitignore
@@ -64,29 +64,9 @@ AWS EC2/deploy-kubernetes/base/secrets.yaml
 AWS EC2/deploy-kubernetes/ingress/ip-whitelist-middleware.yaml
 AWS EC2/deploy-docker-compose/nginx/ssl/*.key
 AWS EC2/deploy-docker-compose/nginx/ssl/*.crt
-/deploy-docker-compose/nginx/certbot/conf/live/api.thock.site/cert.pem
-/deploy-docker-compose/nginx/certbot/conf/archive/api.thock.site/cert1.pem
-/deploy-docker-compose/nginx/certbot/conf/live/api.thock.site/chain.pem
-/deploy-docker-compose/nginx/certbot/conf/archive/api.thock.site/chain1.pem
+/deploy-docker-compose/.env
+/deploy-docker-compose/release-state.env
+/deploy-docker-compose/logs/
 /deploy-docker-compose/compose.sh
-/deploy-docker-compose/monitoring/grafana/provisioning/dashboards/dashboards.yml
-/deploy-docker-compose/monitoring/grafana/provisioning/datasources/datasources.yml
-/deploy-docker-compose/nginx/certbot/conf/live/api.thock.site/fullchain.pem
-/deploy-docker-compose/nginx/certbot/conf/archive/api.thock.site/fullchain1.pem
-/deploy-docker-compose/docker/init-databases.sql
-/deploy-docker-compose/monitoring/grafana/dashboards/logs-dashboard.json
-/deploy-docker-compose/monitoring/loki/loki-config.yml
-/deploy-docker-compose/nginx/certbot/conf/accounts/acme-v02.api.letsencrypt.org/directory/82a476c42ef082ba62e6594e0da38653/meta.json
-/deploy-docker-compose/nginx/nginx.conf
-/deploy-docker-compose/monitoring/grafana/dashboards/payment-service-dashboard.json
-/deploy-docker-compose/nginx/certbot/conf/accounts/acme-v02.api.letsencrypt.org/directory/82a476c42ef082ba62e6594e0da38653/private_key.json
-/deploy-docker-compose/nginx/certbot/conf/live/api.thock.site/privkey.pem
-/deploy-docker-compose/nginx/certbot/conf/archive/api.thock.site/privkey1.pem
-/deploy-docker-compose/monitoring/prometheus/prometheus.yml
-/deploy-docker-compose/monitoring/promtail/promtail-config.yml
-/deploy-docker-compose/nginx/certbot/conf/live/api.thock.site/README
-/deploy-docker-compose/nginx/certbot/conf/live/README
-/deploy-docker-compose/nginx/certbot/conf/accounts/acme-v02.api.letsencrypt.org/directory/82a476c42ef082ba62e6594e0da38653/regr.json
-/deploy-docker-compose/nginx/ssl/server.crt
-/deploy-docker-compose/nginx/ssl/server.key
-/deploy-docker-compose/monitoring/grafana/dashboards/spring-boot-overview.json
+/deploy-docker-compose/nginx/ssl/
+/deploy-docker-compose/nginx/certbot/

--- a/deploy-docker-compose/docker-compose.yml
+++ b/deploy-docker-compose/docker-compose.yml
@@ -1,0 +1,368 @@
+  services:
+    # ==================== API Gateway (외부 진입점) ====================
+    api-gateway:
+      image: sang234/api-gateway:${API_GATEWAY_IMAGE_TAG:?required}
+      container_name: api-gateway
+      expose:
+        - "8080"
+      env_file:
+        - .env
+      environment:
+        TZ: Asia/Seoul
+        JAVA_TOOL_OPTIONS: "-Duser.timezone=Asia/Seoul -Xms256m -Xmx512m"
+        SPRING_PROFILES_ACTIVE: prod
+        JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+        LOG_PATH: /app/logs
+      volumes:
+        - ./logs/api-gateway:/app/logs
+      depends_on:
+        mysql:
+          condition: service_healthy
+        redpanda:
+          condition: service_started
+        member-service:
+          condition: service_started
+        product-service:
+          condition: service_started
+        market-service:
+          condition: service_started
+        payment-service:
+          condition: service_started
+        settlement-service:
+          condition: service_started
+      networks:
+        - internal
+      restart: unless-stopped
+
+    # ==================== Application Services ====================
+    member-service:
+      image: sang234/member-service:${MEMBER_SERVICE_IMAGE_TAG:?required}
+      container_name: member-service
+      expose:
+        - "8081"
+      env_file:
+        - .env
+      environment:
+        TZ: Asia/Seoul
+        JAVA_TOOL_OPTIONS: "-Duser.timezone=Asia/Seoul -Xms256m -Xmx512m"
+        SPRING_PROFILES_ACTIVE: prod
+        MYSQL_HOST: mysql
+        MYSQL_PORT: 3306
+        MYSQL_DATABASE: thock_member_db
+        MYSQL_USER: thock_member_db_user
+        MYSQL_PASSWORD: ${MEMBER_DB_PASSWORD}
+        KAFKA_BOOTSTRAP_SERVERS: redpanda:29092
+        REDIS_HOST: redis
+        REDIS_PORT: 6379
+        LOG_PATH: /app/logs
+      volumes:
+        - ./logs/member:/app/logs
+      depends_on:
+        mysql:
+          condition: service_healthy
+        redpanda:
+          condition: service_started
+        redis:
+          condition: service_started
+      networks:
+        - internal
+      restart: unless-stopped
+
+    product-service:
+      image: sang234/product-service:${PRODUCT_SERVICE_IMAGE_TAG:?required}
+      container_name: product-service
+      expose:
+        - "8082"
+      env_file:
+        - .env
+      environment:
+        TZ: Asia/Seoul
+        JAVA_TOOL_OPTIONS: "-Duser.timezone=Asia/Seoul -Xms256m -Xmx512m"
+        SPRING_PROFILES_ACTIVE: prod
+        MYSQL_HOST: mysql
+        MYSQL_PORT: 3306
+        MYSQL_DATABASE: thock_product_db
+        MYSQL_USER: thock_product_db_user
+        MYSQL_PASSWORD: ${PRODUCT_DB_PASSWORD}
+        KAFKA_BOOTSTRAP_SERVERS: redpanda:29092
+        REDIS_HOST: redis
+        REDIS_PORT: 6379
+        LOG_PATH: /app/logs
+      volumes:
+        - ./logs/product:/app/logs
+      depends_on:
+        mysql:
+          condition: service_healthy
+        redpanda:
+          condition: service_started
+        redis:
+          condition: service_started
+      networks:
+        - internal
+      restart: unless-stopped
+
+    market-service:
+      image: sang234/market-service:${MARKET_SERVICE_IMAGE_TAG:?required}
+      container_name: market-service
+      expose:
+        - "8083"
+      env_file:
+        - .env
+      environment:
+        TZ: Asia/Seoul
+        JAVA_TOOL_OPTIONS: "-Duser.timezone=Asia/Seoul -Xms256m -Xmx512m"
+        SPRING_PROFILES_ACTIVE: prod
+        MYSQL_HOST: mysql
+        MYSQL_PORT: 3306
+        MYSQL_DATABASE: thock_market_db
+        MYSQL_USER: thock_market_db_user
+        MYSQL_PASSWORD: ${MARKET_DB_PASSWORD}
+        PRODUCT_SERVICE_URL: http://product-service:8082
+        PAYMENT_SERVICE_URL: http://payment-service:8084
+        KAFKA_BOOTSTRAP_SERVERS: redpanda:29092
+        LOG_PATH: /app/logs
+      volumes:
+        - ./logs/market:/app/logs
+      depends_on:
+        mysql:
+          condition: service_healthy
+        product-service:
+          condition: service_started
+        payment-service:
+          condition: service_started
+        redpanda:
+          condition: service_started
+      networks:
+        - internal
+      restart: unless-stopped
+
+    payment-service:
+      image: sang234/payment-service:${PAYMENT_SERVICE_IMAGE_TAG:?required}
+      container_name: payment-service
+      expose:
+        - "8084"
+      env_file:
+        - .env
+      environment:
+        TZ: Asia/Seoul
+        JAVA_TOOL_OPTIONS: "-Duser.timezone=Asia/Seoul -Xms256m -Xmx512m"
+        SPRING_PROFILES_ACTIVE: prod
+        MYSQL_HOST: mysql
+        MYSQL_PORT: 3306
+        MYSQL_DATABASE: thock_payment_db
+        MYSQL_USER: thock_payment_db_user
+        MYSQL_PASSWORD: ${PAYMENT_DB_PASSWORD}
+        KAFKA_BOOTSTRAP_SERVERS: redpanda:29092
+        LOG_PATH: /app/logs
+      volumes:
+        - ./logs/payment:/app/logs
+      depends_on:
+        mysql:
+          condition: service_healthy
+        redpanda:
+          condition: service_started
+      networks:
+        - internal
+      restart: unless-stopped
+
+    settlement-service:
+      image: sang234/settlement-service:${SETTLEMENT_SERVICE_IMAGE_TAG:?required}
+      container_name: settlement-service
+      expose:
+        - "8085"
+      env_file:
+        - .env
+      environment:
+        TZ: Asia/Seoul
+        JAVA_TOOL_OPTIONS: "-Duser.timezone=Asia/Seoul -Xms256m -Xmx512m"
+        SPRING_PROFILES_ACTIVE: prod
+        MYSQL_HOST: mysql
+        MYSQL_PORT: 3306
+        MYSQL_DATABASE: thock_settlement_db
+        MYSQL_USER: thock_settlement_db_user
+        MYSQL_PASSWORD: ${SETTLEMENT_DB_PASSWORD}
+        KAFKA_BOOTSTRAP_SERVERS: redpanda:29092
+        LOG_PATH: /app/logs
+      volumes:
+        - ./logs/settlement:/app/logs
+      depends_on:
+        mysql:
+          condition: service_healthy
+        redpanda:
+          condition: service_started
+      networks:
+        - internal
+      restart: unless-stopped
+
+    # ==================== Redis ====================
+    redis:
+      image: redis:7.4-alpine
+      container_name: redis
+      expose:
+        - "6379"
+      command:
+        - redis-server
+        - --appendonly
+        - "yes"
+        - --appendfsync
+        - everysec
+      volumes:
+        - redis-data:/data
+      networks:
+        - internal
+      restart: unless-stopped
+
+    # ==================== Kafka ====================
+    redpanda:
+      image: redpandadata/redpanda:v24.1.1
+      container_name: redpanda
+      command:
+        - redpanda start
+        - --smp=1
+        - --memory=512M
+        - --reserve-memory=0M
+        - --overprovisioned
+        - --node-id=0
+        - --check=false
+        - --kafka-addr=PLAINTEXT://0.0.0.0:29092
+        - --advertise-kafka-addr=PLAINTEXT://redpanda:29092
+      networks:
+        - internal
+      volumes:
+        - redpanda-data:/var/lib/redpanda/data
+      restart: unless-stopped
+
+    redpanda-console:
+      image: redpandadata/console:v2.5.2
+      container_name: redpanda-console
+      depends_on:
+        - redpanda
+      expose:
+        - "8090"
+      environment:
+        KAFKA_BROKERS: redpanda:29092
+        SERVER_BASEPATH: /redpanda        
+        SERVER_SETBASEPATHFROMXFORWARDEDPREFIX: "true"
+        SERVER_LISTENPORT: 8090  
+      networks:
+        - internal
+      restart: unless-stopped
+
+    # ==================== MySQL Database ====================
+    mysql:
+      image: mysql:8.0
+      container_name: thock-mysql
+      environment:
+        MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+        TZ: Asia/Seoul
+      volumes:
+        - mysql-data:/var/lib/mysql
+        - ./docker/init-databases.sql:/docker-entrypoint-initdb.d/init-databases.sql
+      healthcheck:
+        test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+        interval: 10s
+        timeout: 5s
+        retries: 10
+      networks:
+        - internal
+      restart: unless-stopped
+
+    # ==================== Monitoring ====================
+    prometheus:
+      image: prom/prometheus:v2.49.1
+      container_name: prometheus
+      expose:
+        - "9090"
+      volumes:
+        - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+        - prometheus-data:/prometheus
+      command:
+        - '--config.file=/etc/prometheus/prometheus.yml'
+        - '--storage.tsdb.path=/prometheus'
+        - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+        - '--web.console.templates=/usr/share/prometheus/consoles'
+      networks:
+        - internal
+      restart: unless-stopped
+
+    loki:
+      image: grafana/loki:2.9.4
+      container_name: loki
+      expose:
+        - "3100"
+      volumes:
+        - ./monitoring/loki/loki-config.yml:/etc/loki/local-config.yaml
+        - loki-data:/loki
+      command: -config.file=/etc/loki/local-config.yaml
+      healthcheck:
+        test: ["CMD-SHELL", "wget -q --tries=1 -O- http://localhost:3100/ready || exit 1"]
+        interval: 10s
+        timeout: 5s
+        retries: 10
+      networks:
+        - internal
+      restart: unless-stopped
+
+    promtail:
+      image: grafana/promtail:2.9.4
+      container_name: promtail
+      volumes:
+        - ./monitoring/promtail/promtail-config.yml:/etc/promtail/config.yml
+        - ./logs:/var/log/apps:ro
+      command: -config.file=/etc/promtail/config.yml
+      depends_on:
+        loki:
+          condition: service_healthy
+      networks:
+        - internal
+      restart: unless-stopped
+
+    grafana:
+      image: grafana/grafana:10.3.1
+      container_name: grafana
+      expose:
+        - "3000"
+      environment:
+        GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER}
+        GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+        GF_USERS_ALLOW_SIGN_UP: "false"
+        GF_SERVER_ROOT_URL: http://13.209.190.62/grafana/
+        GF_SERVER_SERVE_FROM_SUB_PATH: "true"         
+      volumes:
+        - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
+        - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
+        - grafana-data:/var/lib/grafana
+      depends_on:
+        - prometheus
+        - loki
+      networks:
+        - internal
+      restart: unless-stopped
+
+    # ==================== Nginx (HTTP Reverse Proxy) ====================
+    nginx:
+      image: nginx:1.27.4
+      container_name: nginx
+      ports:
+        - "80:80"
+      volumes:
+        - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      depends_on:
+        - api-gateway
+      networks:
+        - internal
+      restart: unless-stopped
+
+  # ==================== Networks ====================
+  networks:
+    internal:
+      driver: bridge
+
+  # ==================== Volumes ====================
+  volumes:
+    mysql-data:
+    redis-data:
+    redpanda-data:
+    prometheus-data:
+    loki-data:
+    grafana-data:

--- a/deploy-docker-compose/docker/init-databases.sql
+++ b/deploy-docker-compose/docker/init-databases.sql
@@ -1,0 +1,23 @@
+-- Create all databases for microservices
+CREATE DATABASE IF NOT EXISTS thock_member_db;
+CREATE DATABASE IF NOT EXISTS thock_product_db;
+CREATE DATABASE IF NOT EXISTS thock_market_db;
+CREATE DATABASE IF NOT EXISTS thock_payment_db;
+CREATE DATABASE IF NOT EXISTS thock_settlement_db;
+
+-- Create users for each service
+CREATE USER IF NOT EXISTS 'thock_member_db_user'@'%' IDENTIFIED BY 'thock_member_db_password';
+CREATE USER IF NOT EXISTS 'thock_product_db_user'@'%' IDENTIFIED BY 'thock_product_db_password';
+CREATE USER IF NOT EXISTS 'thock_market_db_user'@'%' IDENTIFIED BY 'thock_market_db_password';
+CREATE USER IF NOT EXISTS 'thock_payment_db_user'@'%' IDENTIFIED BY 'thock_payment_db_password';
+CREATE USER IF NOT EXISTS 'thock_settlement_db_user'@'%' IDENTIFIED BY 'thock_settlement_db_password';
+
+-- Grant privileges (each user can only access their own database)
+GRANT ALL PRIVILEGES ON thock_member_db.* TO 'thock_member_db_user'@'%';
+GRANT ALL PRIVILEGES ON thock_product_db.* TO 'thock_product_db_user'@'%';
+GRANT ALL PRIVILEGES ON thock_market_db.* TO 'thock_market_db_user'@'%';
+GRANT ALL PRIVILEGES ON thock_payment_db.* TO 'thock_payment_db_user'@'%';
+GRANT ALL PRIVILEGES ON thock_settlement_db.* TO 'thock_settlement_db_user'@'%';
+
+FLUSH PRIVILEGES;
+

--- a/deploy-docker-compose/monitoring/grafana/dashboards/logs-dashboard.json
+++ b/deploy-docker-compose/monitoring/grafana/dashboards/logs-dashboard.json
@@ -1,0 +1,275 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 0 },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service=~\"$service\", log_type=~\"$log_type\"}[1m])) by (service)",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Volume by Service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 0 },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service=~\"$service\", log_type=~\"$log_type\"}[1m])) by (log_type)",
+          "legendFormat": "{{log_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Volume by Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "ERROR" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "WARN" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "INFO" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "DEBUG" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 6 },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service=~\"$service\", log_type=~\"$log_type\"}[1m])) by (level)",
+          "legendFormat": "{{level}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Level Distribution",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 12 },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "expr": "{service=~\"$service\", log_type=~\"$log_type\", level=~\"$level\"} |~ \"$search\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Application Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 24 },
+      "id": 4,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "expr": "{service=~\"$service\", log_type=~\"$log_type\"} |~ \"ERROR|WARN\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Error & Warning Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["logs", "loki", "microservices"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "definition": "label_values(service)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": "label_values(service)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "definition": "label_values(log_type)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Log Type",
+        "multi": true,
+        "name": "log_type",
+        "options": [],
+        "query": "label_values(log_type)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "definition": "label_values(level)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Level",
+        "multi": true,
+        "name": "level",
+        "options": [],
+        "query": "label_values(level)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Search",
+        "name": "search",
+        "options": [],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Application Logs",
+  "uid": "logs-dashboard",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy-docker-compose/monitoring/grafana/dashboards/payment-service-dashboard.json
+++ b/deploy-docker-compose/monitoring/grafana/dashboards/payment-service-dashboard.json
@@ -1,0 +1,513 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["sum"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service=~\"$service\", log_type=\"service-info\", level=~\"$level\", logger=~\"$logger\"} |~ \"$search\"[$__range]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Total INFO Logs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["sum"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service=~\"$service\", log_type=\"service-error\", level=~\"$level\", logger=~\"$logger\"} |~ \"$search\"[$__range]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Total ERROR Logs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["sum"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service=~\"$service\", log_type=\"service-info\", level=~\"$level\", logger=~\"$logger\"} |~ \"환불 완료\" |~ \"$search\"[$__range]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Refund Success",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "orange"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["sum"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service=~\"$service\", log_type=\"service-error\", level=~\"$level\", logger=~\"$logger\"} |~ \"환불|취소\" |~ \"$search\"[$__range]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Refund Errors",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "service-error" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "service-info" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service=~\"$service\", log_type=~\"$log_type\", level=~\"$level\", logger=~\"$logger\"} |~ \"$search\"[1m])) by (log_type)",
+          "legendFormat": "{{log_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Service Logs Over Time (Info vs Error)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum(count_over_time({service=~\"$service\", log_type=~\"$log_type\", level=~\"$level\", logger=~\"$logger\"} |~ \"$search\"[1m])) by (logger))",
+          "legendFormat": "{{logger}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs by Logger (Class)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 12 },
+      "id": 7,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "expr": "{service=~\"$service\", log_type=\"service-info\", level=~\"$level\", logger=~\"$logger\"} |~ \"$search\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Service INFO Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 22 },
+      "id": 8,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "expr": "{service=~\"$service\", log_type=\"service-error\", level=~\"$level\", logger=~\"$logger\"} |~ \"$search\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Service ERROR Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "id": 9,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "expr": "{service=~\"$service\", log_type=\"service-info\", level=~\"$level\", logger=~\"$logger\"} |~ \"토스.*완료|검증 완료\" |~ \"$search\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Toss Payment Success Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "id": 10,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "expr": "{service=~\"$service\", log_type=\"service-error\", level=~\"$level\", logger=~\"$logger\"} |~ \"토스|결제 확인 실패|결제 취소 실패\" |~ \"$search\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Toss Payment Error Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["payment", "service", "logs", "loki"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": ["payment"],
+          "value": ["payment"]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "definition": "label_values(service)",
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "Service",
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": "label_values(service)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "definition": "label_values({service=~\"$service\"}, log_type)",
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "Log Type",
+        "multi": true,
+        "name": "log_type",
+        "options": [],
+        "query": "label_values({service=~\"$service\"}, log_type)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "definition": "label_values({service=~\"$service\", log_type=~\"$log_type\"}, level)",
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "Level",
+        "multi": true,
+        "name": "level",
+        "options": [],
+        "query": "label_values({service=~\"$service\", log_type=~\"$log_type\"}, level)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "definition": "label_values({service=~\"$service\", log_type=~\"$log_type\"}, logger)",
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "Logger",
+        "multi": true,
+        "name": "logger",
+        "options": [],
+        "query": "label_values({service=~\"$service\", log_type=~\"$log_type\"}, logger)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Search",
+        "name": "search",
+        "options": [],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "Asia/Seoul",
+  "title": "Payment Service Dashboard",
+  "uid": "payment-service-dashboard",
+  "version": 2,
+  "weekStart": ""
+}

--- a/deploy-docker-compose/monitoring/grafana/dashboards/spring-boot-overview.json
+++ b/deploy-docker-compose/monitoring/grafana/dashboards/spring-boot-overview.json
@@ -1,0 +1,304 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 80 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "up{job=~\".*-service\"}",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Services Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=~\".*-service\"}[5m])) by (job)",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate (per service)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{job=~\".*-service\"}[5m])) by (le, job))",
+          "legendFormat": "{{job}} p95",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Response Time (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 70 },
+              { "color": "red", "value": 85 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes{job=~\".*-service\"}) by (job) / sum(jvm_memory_max_bytes{job=~\".*-service\"}) by (job) * 100",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ],
+      "title": "JVM Memory Usage (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "hikaricp_connections_active{job=~\".*-service\"}",
+          "legendFormat": "{{job}} - active",
+          "refId": "A"
+        },
+        {
+          "expr": "hikaricp_connections_idle{job=~\".*-service\"}",
+          "legendFormat": "{{job}} - idle",
+          "refId": "B"
+        }
+      ],
+      "title": "HikariCP Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=~\".*-service\", status=~\"5..\"}[5m])) by (job)",
+          "legendFormat": "{{job}} - 5xx errors",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=~\".*-service\", status=~\"4..\"}[5m])) by (job)",
+          "legendFormat": "{{job}} - 4xx errors",
+          "refId": "B"
+        }
+      ],
+      "title": "HTTP Errors",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["spring-boot", "microservices"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Spring Boot Services Overview",
+  "uid": "spring-boot-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy-docker-compose/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy-docker-compose/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    folderUid: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deploy-docker-compose/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/deploy-docker-compose/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      maxLines: 1000

--- a/deploy-docker-compose/monitoring/loki/loki-config.yml
+++ b/deploy-docker-compose/monitoring/loki/loki-config.yml
@@ -1,0 +1,47 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+limits_config:
+  reject_old_samples: false
+  reject_old_samples_max_age: 168h
+  ingestion_rate_mb: 16
+  ingestion_burst_size_mb: 24
+  max_query_lookback: 0s
+
+analytics:
+  reporting_enabled: false

--- a/deploy-docker-compose/monitoring/prometheus/prometheus.yml
+++ b/deploy-docker-compose/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,69 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: []
+
+rule_files: []
+
+scrape_configs:
+  # Prometheus self-monitoring
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # API Gateway
+  - job_name: 'api-gateway'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['api-gateway:8080']
+    scrape_interval: 10s
+
+  # Member Service
+  - job_name: 'member-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['member-service:8081']
+    scrape_interval: 10s
+
+  # Product Service
+  - job_name: 'product-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['product-service:8082']
+    scrape_interval: 10s
+
+  # Market Service
+  - job_name: 'market-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['market-service:8083']
+    scrape_interval: 10s
+
+  # Payment Service
+  - job_name: 'payment-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['payment-service:8084']
+    scrape_interval: 10s
+
+  # Settlement Service
+  - job_name: 'settlement-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['settlement-service:8085']
+    scrape_interval: 10s
+
+  # MySQL Exporter (optional - if you add mysql-exporter)
+  # - job_name: 'mysql'
+  #   static_configs:
+  #     - targets: ['mysql-exporter:9104']
+
+  # Redpanda/Kafka metrics
+  - job_name: 'redpanda'
+    static_configs:
+      - targets: ['redpanda:9644']
+    scrape_interval: 10s

--- a/deploy-docker-compose/monitoring/promtail/promtail-config.yml
+++ b/deploy-docker-compose/monitoring/promtail/promtail-config.yml
@@ -1,0 +1,382 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # ==================== Member Service ====================
+  - job_name: member-app
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: member-service
+          service: member
+          log_type: app
+          __path__: /var/log/apps/member/app*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            logger: logger_name
+            message: message
+      - labels:
+          level:
+          logger:
+
+  - job_name: member-api
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: member-service
+          service: member
+          log_type: api
+          __path__: /var/log/apps/member/api*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            logger: logger_name
+            message: message
+      - labels:
+          level:
+
+  - job_name: member-kafka-event
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: member-service
+          service: member
+          log_type: kafka-event
+          __path__: /var/log/apps/member/kafka-event*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  - job_name: member-spring-event
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: member-service
+          service: member
+          log_type: spring-event
+          __path__: /var/log/apps/member/spring-event*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  # ==================== Product Service ====================
+  - job_name: product-app
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: product-service
+          service: product
+          log_type: app
+          __path__: /var/log/apps/product/app*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            logger: logger_name
+            message: message
+      - labels:
+          level:
+          logger:
+
+  - job_name: product-api
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: product-service
+          service: product
+          log_type: api
+          __path__: /var/log/apps/product/api*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  - job_name: product-kafka-event
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: product-service
+          service: product
+          log_type: kafka-event
+          __path__: /var/log/apps/product/kafka-event*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  - job_name: product-spring-event
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: product-service
+          service: product
+          log_type: spring-event
+          __path__: /var/log/apps/product/spring-event*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  # ==================== Market Service ====================
+  - job_name: market-app
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: market-service
+          service: market
+          log_type: app
+          __path__: /var/log/apps/market/app*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            logger: logger_name
+            message: message
+      - labels:
+          level:
+          logger:
+
+  - job_name: market-api
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: market-service
+          service: market
+          log_type: api
+          __path__: /var/log/apps/market/api*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  - job_name: market-kafka-event
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: market-service
+          service: market
+          log_type: kafka-event
+          __path__: /var/log/apps/market/kafka-event*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  - job_name: market-spring-event
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: market-service
+          service: market
+          log_type: spring-event
+          __path__: /var/log/apps/market/spring-event*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  # ==================== Payment Service ====================
+  - job_name: payment-app
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: payment-service
+          service: payment
+          log_type: app
+          __path__: /var/log/apps/payment/app*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            logger: logger_name
+            message: message
+      - labels:
+          level:
+          logger:
+
+  - job_name: payment-api
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: payment-service
+          service: payment
+          log_type: api
+          __path__: /var/log/apps/payment/api*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  - job_name: payment-kafka-event
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: payment-service
+          service: payment
+          log_type: kafka-event
+          __path__: /var/log/apps/payment/kafka-event*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  - job_name: payment-spring-event
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: payment-service
+          service: payment
+          log_type: spring-event
+          __path__: /var/log/apps/payment/spring-event*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  - job_name: payment-service-info
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: payment-service
+          service: payment
+          log_type: service-info
+          __path__: /var/log/apps/payment/service-info*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            logger: logger_name
+            message: message
+      - labels:
+          level:
+          logger:
+
+  - job_name: payment-service-error
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: payment-service
+          service: payment
+          log_type: service-error
+          __path__: /var/log/apps/payment/service-error*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            logger: logger_name
+            message: message
+      - labels:
+          level:
+          logger:
+
+  # ==================== Settlement Service ====================
+  - job_name: settlement-app
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: settlement-service
+          service: settlement
+          log_type: app
+          __path__: /var/log/apps/settlement/app*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            logger: logger_name
+            message: message
+      - labels:
+          level:
+          logger:
+
+  - job_name: settlement-api
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: settlement-service
+          service: settlement
+          log_type: api
+          __path__: /var/log/apps/settlement/api*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  - job_name: settlement-kafka-event
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: settlement-service
+          service: settlement
+          log_type: kafka-event
+          __path__: /var/log/apps/settlement/kafka-event*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:
+
+  - job_name: settlement-spring-event
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: settlement-service
+          service: settlement
+          log_type: spring-event
+          __path__: /var/log/apps/settlement/spring-event*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            message: message
+      - labels:
+          level:

--- a/deploy-docker-compose/nginx/nginx.conf
+++ b/deploy-docker-compose/nginx/nginx.conf
@@ -1,0 +1,67 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    resolver 127.0.0.11 ipv6=off valid=10s;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    server {
+        listen 80;
+        server_name 13.209.190.62 _;
+
+        location = /grafana {
+            return 301 /grafana/;
+        }
+
+        location ^~ /grafana/ {
+            proxy_pass http://grafana:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 60s;
+        }
+
+        location = /redpanda {
+            return 301 /redpanda/;
+        }
+
+        location ^~ /redpanda/ {
+            proxy_pass http://redpanda-console:8090;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Prefix /redpanda;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 60s;
+        }
+
+        location ^~ /actuator/ {
+            return 403;
+        }
+
+        location / {
+            proxy_pass http://api-gateway:8080;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization $http_authorization;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 60s;
+        }
+    }
+}

--- a/market-service/build.gradle
+++ b/market-service/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security' // 인증 및 권한 부여를 위한 스프링 시큐리티
     implementation 'org.springframework.boot:spring-boot-starter-webflux' // webClient
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'

--- a/market-service/src/main/resources/application-test.yml
+++ b/market-service/src/main/resources/application-test.yml
@@ -13,6 +13,9 @@ spring:
     username: ${TEST_DB_USERNAME:test}
     password: ${TEST_DB_PASSWORD:test}
 
+  flyway:
+    enabled: false
+
   jpa:
     hibernate:
       ddl-auto: create-drop

--- a/market-service/src/main/resources/application.yml
+++ b/market-service/src/main/resources/application.yml
@@ -11,6 +11,10 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  flyway:
+    baseline-on-migrate: true
+    baseline-version: 0
+
   jpa:
     show-sql: true
     properties:

--- a/market-service/src/main/resources/db/migration/V1__create_market_cart_product_views.sql
+++ b/market-service/src/main/resources/db/migration/V1__create_market_cart_product_views.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS `market_cart_product_views`
+(
+    `id`             bigint       NOT NULL AUTO_INCREMENT,
+    `product_id`     bigint       NOT NULL,
+    `seller_id`      bigint DEFAULT NULL,
+    `name`           varchar(255) DEFAULT NULL,
+    `image_url`      varchar(255) DEFAULT NULL,
+    `price`          bigint DEFAULT NULL,
+    `sale_price`     bigint DEFAULT NULL,
+    `stock`          int DEFAULT NULL,
+    `reserved_stock` int DEFAULT NULL,
+    `product_state`  varchar(255) DEFAULT NULL,
+    `deleted`        bit(1)       NOT NULL,
+    `created_at`     datetime(6) DEFAULT NULL,
+    `updated_at`     datetime(6) DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_market_cart_product_views_product_id` (`product_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
## 관련 이슈
Closes #45

## 변경 내용
- 배포용 `deploy-docker-compose/docker-compose.yml`를 리포에 포함하고 Redis 서비스를 추가했습니다.
- `member-service`, `product-service`가 배포 환경에서 `redis:6379`를 바라보도록 환경변수와 `depends_on`을 반영했습니다.
- GitHub Actions CD에서 `deploy-docker-compose/`를 EC2 `~/deploy-docker-compose`로 동기화하도록 수정했습니다.
- 배포 전에 `mysql`, `redpanda`, `redis`를 먼저 기동하도록 변경했습니다.
- `market-service`에 Flyway를 도입하고 `market_cart_product_views` 생성 migration을 추가했습니다.
- 운영 DB가 이미 존재하는 상황을 고려해 `baseline-on-migrate`를 적용했습니다.
- `.env`, `release-state.env`, 로그, 인증서/개인키를 제외한 배포 설정 파일을 Git 관리 대상으로 정리했습니다.

## 확인 내용
- `member-service` Redis 접속 기본값 `localhost:6379` 문제를 배포 설정으로 해결
- `market-service` 읽기 전용 테이블을 운영에서도 Flyway로 생성 가능하도록 변경

## 참고
- 레포가 관리하는 배포 설정은 이제 CD 실행 시 EC2 `~/deploy-docker-compose`로 동기화됩니다.
- 동기화 제외 대상:
  - `.env`
  - `release-state.env`
  - `logs/`
  - `compose.sh`
  - `nginx/ssl/`
  - `nginx/certbot/`