### PR TITLE
[TASK] CI/CD 배포 후 smoke test 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -311,3 +311,25 @@ jobs:
               echo "[WARN] nginx container is not running. Skipping nginx reload."
             fi
           EOF
+
+      - name: Smoke test public gateway route
+        run: |
+          set -euo pipefail
+
+          TARGET_URL="http://${{ secrets.EC2_HOST }}/member-service/v3/api-docs"
+
+          for attempt in 1 2 3 4 5; do
+            echo "Smoke test attempt ${attempt}: ${TARGET_URL}"
+
+            response="$(curl --silent --show-error --location --max-time 15 "${TARGET_URL}" || true)"
+
+            if printf '%s' "${response}" | grep -q '"openapi"'; then
+              echo "Smoke test passed."
+              exit 0
+            fi
+
+            sleep 5
+          done
+
+          echo "[ERROR] public smoke test failed: ${TARGET_URL}"
+          exit 1


### PR DESCRIPTION
## 변경 내용
- CD 워크플로우에 배포 후 public smoke test 단계를 추가했습니다.
- `http://{EC2_HOST}/member-service/v3/api-docs`를 외부에서 직접 호출해 `nginx -> api-gateway -> member-service` 공개 경로가 정상 동작하는지 검증합니다.
- 응답 본문에 `"openapi"`가 포함되는지 확인하고, 실패 시 워크플로우를 실패 처리하도록 구성했습니다.
- 일시적인 기동 지연을 고려해 최대 5회 재시도하도록 추가했습니다.

## 기대 효과
- 컨테이너 health check만으로는 놓칠 수 있는 공개 진입 경로 문제를 배포 직후 바로 감지할 수 있습니다.
- `nginx`, `gateway`, 대상 서비스까지 포함한 실제 사용자 경로를 검증할 수 있습니다.