### PR TITLE
[TASK] CI/CD 배포 후 smoke test 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      any_changed: ${{ steps.filter.outputs.any_changed }}
+      any_service_changed: ${{ steps.filter.outputs.any_service_changed }}
+      any_deploy_changed: ${{ steps.filter.outputs.any_deploy_changed }}
       services_json: ${{ steps.filter.outputs.services_json }}
       services_space: ${{ steps.filter.outputs.services_space }}
 
@@ -33,8 +34,12 @@ jobs:
               'settlement-service',
             ];
 
-            const setDefaultOutputs = (selectedServices) => {
-              core.setOutput('any_changed', selectedServices.length > 0 ? 'true' : 'false');
+            const setOutputs = (selectedServices, deployChanged) => {
+              core.setOutput('any_service_changed', selectedServices.length > 0 ? 'true' : 'false');
+              core.setOutput(
+                'any_deploy_changed',
+                deployChanged || selectedServices.length > 0 ? 'true' : 'false'
+              );
               core.setOutput('services_json', JSON.stringify(selectedServices));
               core.setOutput('services_space', selectedServices.join(' '));
             };
@@ -42,7 +47,7 @@ jobs:
             const pr = context.payload.pull_request;
             if (!pr.merged) {
               core.info('Pull request was closed without merge. Skipping build and deploy.');
-              setDefaultOutputs([]);
+              setOutputs([], false);
               return;
             }
 
@@ -81,6 +86,14 @@ jobs:
               'gradlew.bat',
             ]);
 
+            const deployPrefixes = [
+              'deploy-docker-compose/',
+            ];
+
+            const deployFiles = new Set([
+              '.github/workflows/deploy.yml',
+            ]);
+
             const impacted = new Set();
             const impactsAllServices = changedFiles.some((file) => {
               if (globalFiles.has(file)) {
@@ -88,6 +101,14 @@ jobs:
               }
 
               return globalPrefixes.some((prefix) => file.startsWith(prefix));
+            });
+
+            const deployChanged = changedFiles.some((file) => {
+              if (deployFiles.has(file)) {
+                return true;
+              }
+
+              return deployPrefixes.some((prefix) => file.startsWith(prefix));
             });
 
             if (impactsAllServices) {
@@ -111,12 +132,18 @@ jobs:
                 : 'No service image changes detected.'
             );
 
-            setDefaultOutputs(selectedServices);
+            core.info(
+              deployChanged
+                ? 'Deploy-related changes detected.'
+                : 'No deploy-related changes detected.'
+            );
+
+            setOutputs(selectedServices, deployChanged);
 
   build-and-push:
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: github.event.pull_request.merged == true && needs.detect-changes.outputs.any_changed == 'true'
+    if: github.event.pull_request.merged == true && needs.detect-changes.outputs.any_service_changed == 'true'
 
     # CHANGED: merge된 PR의 커밋 SHA를 이미지 태그로 사용
     env:
@@ -155,7 +182,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [detect-changes, build-and-push]
-    if: github.event.pull_request.merged == true && needs.detect-changes.outputs.any_changed == 'true'
+    if: >
+      github.event.pull_request.merged == true &&
+      needs.detect-changes.outputs.any_deploy_changed == 'true' &&
+      (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'skipped')
 
     # CHANGED: deploy job에서도 동일 태그 사용
     env:
@@ -199,11 +229,6 @@ jobs:
             IMAGE_TAG="${IMAGE_TAG}"
             DEPLOY_DIR="\$HOME/deploy-docker-compose"
 
-            if [ -z "\$CHANGED_SERVICES" ]; then
-              echo "No service image changes detected."
-              exit 0
-            fi
-
             if [ ! -d "\$DEPLOY_DIR" ]; then
               echo "[ERROR] deploy directory not found: \$DEPLOY_DIR"
               exit 1
@@ -220,88 +245,96 @@ jobs:
               docker compose --env-file .env --env-file release-state.env -f docker-compose.yml "\$@"
             }
 
-            for svc in \$CHANGED_SERVICES; do
-              case "\$svc" in
-                api-gateway)
-                  port=8080
-                  tag_var=API_GATEWAY_IMAGE_TAG
-                  ;;
-                member-service)
-                  port=8081
-                  tag_var=MEMBER_SERVICE_IMAGE_TAG
-                  ;;
-                product-service)
-                  port=8082
-                  tag_var=PRODUCT_SERVICE_IMAGE_TAG
-                  ;;
-                market-service)
-                  port=8083
-                  tag_var=MARKET_SERVICE_IMAGE_TAG
-                  ;;
-                payment-service)
-                  port=8084
-                  tag_var=PAYMENT_SERVICE_IMAGE_TAG
-                  ;;
-                settlement-service)
-                  port=8085
-                  tag_var=SETTLEMENT_SERVICE_IMAGE_TAG
-                  ;;
-                *)
-                  echo "[ERROR] unknown service: \$svc"
-                  exit 1
-                  ;;
-              esac
-
-              if grep -q "^\${tag_var}=" release-state.env; then
-                sed -i "s|^\${tag_var}=.*|\${tag_var}=\${IMAGE_TAG}|" release-state.env
-              else
-                echo "\${tag_var}=\${IMAGE_TAG}" >> release-state.env
-              fi
-            done
-
             compose config >/dev/null
             compose up -d mysql redpanda redis
-            compose pull \$CHANGED_SERVICES
-            compose up -d --no-deps \$CHANGED_SERVICES
+
+            if [ -n "\$CHANGED_SERVICES" ]; then
+              for svc in \$CHANGED_SERVICES; do
+                case "\$svc" in
+                  api-gateway)
+                    port=8080
+                    tag_var=API_GATEWAY_IMAGE_TAG
+                    ;;
+                  member-service)
+                    port=8081
+                    tag_var=MEMBER_SERVICE_IMAGE_TAG
+                    ;;
+                  product-service)
+                    port=8082
+                    tag_var=PRODUCT_SERVICE_IMAGE_TAG
+                    ;;
+                  market-service)
+                    port=8083
+                    tag_var=MARKET_SERVICE_IMAGE_TAG
+                    ;;
+                  payment-service)
+                    port=8084
+                    tag_var=PAYMENT_SERVICE_IMAGE_TAG
+                    ;;
+                  settlement-service)
+                    port=8085
+                    tag_var=SETTLEMENT_SERVICE_IMAGE_TAG
+                    ;;
+                  *)
+                    echo "[ERROR] unknown service: \$svc"
+                    exit 1
+                    ;;
+                esac
+
+                if grep -q "^\${tag_var}=" release-state.env; then
+                  sed -i "s|^\${tag_var}=.*|\${tag_var}=\${IMAGE_TAG}|" release-state.env
+                else
+                  echo "\${tag_var}=\${IMAGE_TAG}" >> release-state.env
+                fi
+              done
+
+              compose pull \$CHANGED_SERVICES
+              compose up -d --no-deps \$CHANGED_SERVICES
+            else
+              echo "No service image changes detected. Skipping image pull and service restart."
+            fi
+
             compose up -d nginx
 
-            for svc in \$CHANGED_SERVICES; do
-              case "\$svc" in
-                api-gateway) port=8080 ;;
-                member-service) port=8081 ;;
-                product-service) port=8082 ;;
-                market-service) port=8083 ;;
-                payment-service) port=8084 ;;
-                settlement-service) port=8085 ;;
-                *)
-                  echo "[ERROR] unknown service: \$svc"
-                  exit 1
-                  ;;
-              esac
+            if [ -n "\$CHANGED_SERVICES" ]; then
+              for svc in \$CHANGED_SERVICES; do
+                case "\$svc" in
+                  api-gateway) port=8080 ;;
+                  member-service) port=8081 ;;
+                  product-service) port=8082 ;;
+                  market-service) port=8083 ;;
+                  payment-service) port=8084 ;;
+                  settlement-service) port=8085 ;;
+                  *)
+                    echo "[ERROR] unknown service: \$svc"
+                    exit 1
+                    ;;
+                esac
 
-              actual_image=\$(docker inspect --format '{{.Config.Image}}' "\$svc")
-              expected_image="sang234/\$svc:\${IMAGE_TAG}"
-              if [ "\$actual_image" != "\$expected_image" ]; then
-                echo "[ERROR] image tag mismatch for \$svc"
-                echo "  expected: \$expected_image"
-                echo "  actual  : \$actual_image"
-                exit 1
-              fi
-
-              elapsed=0
-              until docker exec "\$svc" sh -lc "wget -qO- http://127.0.0.1:\$port/actuator/health" >/dev/null 2>&1; do
-                elapsed=\$((elapsed + 5))
-                if [ "\$elapsed" -ge 180 ]; then
-                  echo "[ERROR] health check timed out for \$svc"
-                  docker logs --tail=120 "\$svc" || true
+                actual_image=\$(docker inspect --format '{{.Config.Image}}' "\$svc")
+                expected_image="sang234/\$svc:\${IMAGE_TAG}"
+                if [ "\$actual_image" != "\$expected_image" ]; then
+                  echo "[ERROR] image tag mismatch for \$svc"
+                  echo "  expected: \$expected_image"
+                  echo "  actual  : \$actual_image"
                   exit 1
                 fi
 
-                sleep 5
-              done
+                elapsed=0
+                until docker exec "\$svc" sh -lc "wget -qO- http://127.0.0.1:\$port/actuator/health" >/dev/null 2>&1; do
+                  elapsed=\$((elapsed + 5))
+                  if [ "\$elapsed" -ge 180 ]; then
+                    echo "[ERROR] health check timed out for \$svc"
+                    docker logs --tail=120 "\$svc" || true
+                    exit 1
+                  fi
 
-              echo "\$svc => \$actual_image"
-            done
+                  sleep 5
+                done
+
+                echo "\$svc => \$actual_image"
+              done
+            fi
 
             if docker ps --format '{{.Names}}' | grep -qx 'nginx'; then
               docker exec nginx nginx -t


### PR DESCRIPTION
## 변경 내용
- CD 워크플로우에 배포 후 public smoke test를 추가했습니다.
- `http://{EC2_HOST}/member-service/v3/api-docs`를 외부에서 호출해 `nginx -> api-gateway -> member-service` 공개 경로가 정상 동작하는지 검증합니다.
- 응답 본문에 `"openapi"`가 포함되면 성공 처리하고, 실패 시 워크플로우를 실패 처리하도록 구성했습니다.
- 서비스 이미지 변경이 없더라도 `.github/workflows/deploy.yml` 또는 `deploy-docker-compose/` 변경 시 deploy와 smoke test가 실행되도록 change detection 조건을 분리했습니다.