### PR TITLE
[BUG] build skip 시 deploy 미실행 문제 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -222,6 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-changes, build-and-push]
     if: >
+      always() &&
       needs.detect-changes.outputs.any_deploy_changed == 'true' &&
       (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true) &&
       (needs.build-and-push.result == 'success' || needs.build-and-push.result == 'skipped')


### PR DESCRIPTION
## 변경 내용
- `build-and-push`가 skip될 때 `deploy`도 함께 skip되던 조건을 수정했습니다.
- `deploy` job 조건에 `always()`를 추가해, deploy-related changes가 있으면 build skip 상황에서도 deploy와 smoke test가 실행되도록 변경했습니다.