### PR TITLE
[TEST] 장바구니 CQRS Before/After 실험 환경 추가

### DIFF
--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -107,6 +107,53 @@ Useful overrides:
 - `STOCK_EXPERIMENT_EXECUTOR=per-vu`
 - `STOCK_EXPERIMENT_EXECUTOR=shared K6_VUS=200`
 
+Run the cart CQRS before/after experiment with one k6 script.
+
+```bash
+bash loadtest/run-cart-cqrs-experiment.sh
+```
+
+This wrapper enables the `experiment` profile for `product-service` and `market-service`, then runs one k6 script that executes these scenarios sequentially:
+
+- `sync_read`
+- `cqrs_read`
+- `sync_read_delay`
+- `cqrs_read_delay`
+- `sync_add`
+- `cqrs_add`
+- `sync_add_delay`
+- `cqrs_add_delay`
+
+The k6 `setup()` does all dataset preparation:
+
+- creates fresh experiment products in `product-service`
+- seeds read/add member pools in `market-service`
+- syncs the cart CQRS projection for the requested product IDs
+
+Useful overrides:
+
+- `K6_SCENARIO_VUS=30`
+- `K6_SCENARIO_DURATION=20s`
+- `K6_SCENARIO_SLOT_SECONDS=25`
+- `K6_PRODUCT_COUNT=3`
+- `K6_PRODUCT_DELAY_MS=900`
+- `K6_READ_MEMBER_COUNT=50`
+- `K6_ADD_MEMBER_COUNT_PER_SCENARIO=100`
+- `K6_PRODUCT_STOCK=100000`
+
+Key output fields:
+
+- `sync_read.avg`, `cqrs_read.avg`
+- `sync_read_delay.avg`, `cqrs_read_delay.avg`
+- `sync_add.avg`, `cqrs_add.avg`
+- `sync_add_delay.avg`, `cqrs_add_delay.avg`
+- `*_throughput`
+- `*_success_rate`
+- `read_avg_improvement_pct`
+- `read_delay_avg_improvement_pct`
+- `add_avg_improvement_pct`
+- `add_delay_avg_improvement_pct`
+
 Reset the product experiment state cleanly before each run.
 
 ```bash

--- a/loadtest/cart-cqrs-experiment.js
+++ b/loadtest/cart-cqrs-experiment.js
@@ -1,0 +1,451 @@
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { check, fail } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+
+const runId = __ENV.RUN_ID || `${Date.now()}`;
+const productExperimentBaseUrl = (__ENV.PRODUCT_EXPERIMENT_BASE_URL || 'http://product-service:8082').replace(/\/$/, '');
+const marketExperimentBaseUrl = (__ENV.MARKET_EXPERIMENT_BASE_URL || 'http://market-service:8083').replace(/\/$/, '');
+const scenarioDuration = __ENV.SCENARIO_DURATION || '20s';
+const scenarioSlotSeconds = Number(__ENV.SCENARIO_SLOT_SECONDS || 25);
+const scenarioVus = Number(__ENV.SCENARIO_VUS || 30);
+const productCount = Number(__ENV.PRODUCT_COUNT || 3);
+const productStock = Number(__ENV.PRODUCT_STOCK || 100000);
+const productPrice = Number(__ENV.PRODUCT_PRICE || 10000);
+const productSalePrice = Number(__ENV.PRODUCT_SALE_PRICE || 9000);
+const readMemberCount = Number(__ENV.READ_MEMBER_COUNT || 50);
+const addMemberCountPerScenario = Number(__ENV.ADD_MEMBER_COUNT_PER_SCENARIO || 100);
+const readItemQuantity = Number(__ENV.READ_ITEM_QUANTITY || 1);
+const addItemQuantity = Number(__ENV.ADD_ITEM_QUANTITY || 1);
+const productDelayMs = Number(__ENV.PRODUCT_DELAY_MS || 900);
+const baseMemberId = Number(__ENV.BASE_MEMBER_ID || 980000);
+
+const syncReadDuration = new Trend('cart_cqrs_sync_read_duration', true);
+const cqrsReadDuration = new Trend('cart_cqrs_cqrs_read_duration', true);
+const syncReadDelayDuration = new Trend('cart_cqrs_sync_read_delay_duration', true);
+const cqrsReadDelayDuration = new Trend('cart_cqrs_cqrs_read_delay_duration', true);
+const syncAddDuration = new Trend('cart_cqrs_sync_add_duration', true);
+const cqrsAddDuration = new Trend('cart_cqrs_cqrs_add_duration', true);
+const syncAddDelayDuration = new Trend('cart_cqrs_sync_add_delay_duration', true);
+const cqrsAddDelayDuration = new Trend('cart_cqrs_cqrs_add_delay_duration', true);
+
+const syncReadRequests = new Counter('cart_cqrs_sync_read_requests_total');
+const cqrsReadRequests = new Counter('cart_cqrs_cqrs_read_requests_total');
+const syncReadDelayRequests = new Counter('cart_cqrs_sync_read_delay_requests_total');
+const cqrsReadDelayRequests = new Counter('cart_cqrs_cqrs_read_delay_requests_total');
+const syncAddRequests = new Counter('cart_cqrs_sync_add_requests_total');
+const cqrsAddRequests = new Counter('cart_cqrs_cqrs_add_requests_total');
+const syncAddDelayRequests = new Counter('cart_cqrs_sync_add_delay_requests_total');
+const cqrsAddDelayRequests = new Counter('cart_cqrs_cqrs_add_delay_requests_total');
+
+const syncReadFailures = new Counter('cart_cqrs_sync_read_failures_total');
+const cqrsReadFailures = new Counter('cart_cqrs_cqrs_read_failures_total');
+const syncReadDelayFailures = new Counter('cart_cqrs_sync_read_delay_failures_total');
+const cqrsReadDelayFailures = new Counter('cart_cqrs_cqrs_read_delay_failures_total');
+const syncAddFailures = new Counter('cart_cqrs_sync_add_failures_total');
+const cqrsAddFailures = new Counter('cart_cqrs_cqrs_add_failures_total');
+const syncAddDelayFailures = new Counter('cart_cqrs_sync_add_delay_failures_total');
+const cqrsAddDelayFailures = new Counter('cart_cqrs_cqrs_add_delay_failures_total');
+
+const syncReadSuccessRate = new Rate('cart_cqrs_sync_read_success_rate');
+const cqrsReadSuccessRate = new Rate('cart_cqrs_cqrs_read_success_rate');
+const syncReadDelaySuccessRate = new Rate('cart_cqrs_sync_read_delay_success_rate');
+const cqrsReadDelaySuccessRate = new Rate('cart_cqrs_cqrs_read_delay_success_rate');
+const syncAddSuccessRate = new Rate('cart_cqrs_sync_add_success_rate');
+const cqrsAddSuccessRate = new Rate('cart_cqrs_cqrs_add_success_rate');
+const syncAddDelaySuccessRate = new Rate('cart_cqrs_sync_add_delay_success_rate');
+const cqrsAddDelaySuccessRate = new Rate('cart_cqrs_cqrs_add_delay_success_rate');
+
+export const options = {
+  scenarios: {
+    sync_read: makeScenario('syncRead', 0),
+    cqrs_read: makeScenario('cqrsRead', 1),
+    sync_read_delay: makeScenario('syncReadDelay', 2),
+    cqrs_read_delay: makeScenario('cqrsReadDelay', 3),
+    sync_add: makeScenario('syncAdd', 4),
+    cqrs_add: makeScenario('cqrsAdd', 5),
+    sync_add_delay: makeScenario('syncAddDelay', 6),
+    cqrs_add_delay: makeScenario('cqrsAddDelay', 7),
+  },
+  thresholds: {
+    cart_cqrs_sync_read_success_rate: ['rate>0.99'],
+    cart_cqrs_cqrs_read_success_rate: ['rate>0.99'],
+    cart_cqrs_sync_read_delay_success_rate: ['rate>0.99'],
+    cart_cqrs_cqrs_read_delay_success_rate: ['rate>0.99'],
+    cart_cqrs_sync_add_success_rate: ['rate>0.99'],
+    cart_cqrs_cqrs_add_success_rate: ['rate>0.99'],
+    cart_cqrs_sync_add_delay_success_rate: ['rate>0.99'],
+    cart_cqrs_cqrs_add_delay_success_rate: ['rate>0.99'],
+  },
+};
+
+export function setup() {
+  const productIds = [];
+
+  for (let index = 0; index < productCount; index += 1) {
+    const response = http.post(
+      `${productExperimentBaseUrl}/api/v1/experiments/stock/products`,
+      JSON.stringify({
+        name: `cart-cqrs-${runId}-${index + 1}`,
+        price: productPrice,
+        salePrice: productSalePrice,
+        stock: productStock,
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        tags: {
+          name: 'cart_cqrs_create_product',
+        },
+      }
+    );
+
+    check(response, {
+      'create experiment product status is 201': (res) => res.status === 201,
+    }) || fail(`failed to create experiment product: status=${response.status} body=${response.body}`);
+
+    productIds.push(response.json().productId);
+  }
+
+  const datasetResponse = http.post(
+    `${marketExperimentBaseUrl}/api/v1/experiments/cart-cqrs/dataset/seed`,
+    JSON.stringify({
+      baseMemberId,
+      productIds,
+      readMemberCount,
+      addMemberCountPerScenario,
+      readItemQuantity,
+      addItemQuantity,
+    }),
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      tags: {
+        name: 'cart_cqrs_seed_dataset',
+      },
+    }
+  );
+
+  check(datasetResponse, {
+    'seed dataset status is 200': (res) => res.status === 200,
+  }) || fail(`failed to seed cart cqrs dataset: status=${datasetResponse.status} body=${datasetResponse.body}`);
+
+  const dataset = datasetResponse.json();
+  if (!dataset || !dataset.productIds || dataset.productIds.length === 0) {
+    fail(`invalid dataset response: body=${datasetResponse.body}`);
+  }
+
+  return dataset;
+}
+
+export function syncRead(data) {
+  const memberId = pickMemberId(data.readMemberIds);
+  const response = http.get(
+    `${marketExperimentBaseUrl}/api/v1/experiments/cart-cqrs/baseline/read/${memberId}`,
+    { tags: { name: 'cart_cqrs_sync_read' } }
+  );
+
+  recordReadResult(
+    response,
+    syncReadDuration,
+    syncReadRequests,
+    syncReadFailures,
+    syncReadSuccessRate,
+    data.productIds.length
+  );
+}
+
+export function cqrsRead(data) {
+  const memberId = pickMemberId(data.readMemberIds);
+  const response = http.get(
+    `${marketExperimentBaseUrl}/api/v1/experiments/cart-cqrs/cqrs/read/${memberId}`,
+    { tags: { name: 'cart_cqrs_cqrs_read' } }
+  );
+
+  recordReadResult(
+    response,
+    cqrsReadDuration,
+    cqrsReadRequests,
+    cqrsReadFailures,
+    cqrsReadSuccessRate,
+    data.productIds.length
+  );
+}
+
+export function syncReadDelay(data) {
+  const memberId = pickMemberId(data.readMemberIds);
+  const response = http.get(
+    `${marketExperimentBaseUrl}/api/v1/experiments/cart-cqrs/baseline/read/${memberId}?productDelayMs=${productDelayMs}`,
+    { tags: { name: 'cart_cqrs_sync_read_delay' } }
+  );
+
+  recordReadResult(
+    response,
+    syncReadDelayDuration,
+    syncReadDelayRequests,
+    syncReadDelayFailures,
+    syncReadDelaySuccessRate,
+    data.productIds.length
+  );
+}
+
+export function cqrsReadDelay(data) {
+  const memberId = pickMemberId(data.readMemberIds);
+  const response = http.get(
+    `${marketExperimentBaseUrl}/api/v1/experiments/cart-cqrs/cqrs/read/${memberId}`,
+    { tags: { name: 'cart_cqrs_cqrs_read_delay' } }
+  );
+
+  recordReadResult(
+    response,
+    cqrsReadDelayDuration,
+    cqrsReadDelayRequests,
+    cqrsReadDelayFailures,
+    cqrsReadDelaySuccessRate,
+    data.productIds.length
+  );
+}
+
+export function syncAdd(data) {
+  const memberId = pickMemberId(data.syncAddMemberIds);
+  const response = http.post(
+    `${marketExperimentBaseUrl}/api/v1/experiments/cart-cqrs/baseline/add/${memberId}`,
+    JSON.stringify({ productId: data.addTargetProductId, quantity: addItemQuantity }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      tags: { name: 'cart_cqrs_sync_add' },
+    }
+  );
+
+  recordAddResult(
+    response,
+    syncAddDuration,
+    syncAddRequests,
+    syncAddFailures,
+    syncAddSuccessRate,
+    data.addTargetProductId
+  );
+}
+
+export function cqrsAdd(data) {
+  const memberId = pickMemberId(data.cqrsAddMemberIds);
+  const response = http.post(
+    `${marketExperimentBaseUrl}/api/v1/experiments/cart-cqrs/cqrs/add/${memberId}`,
+    JSON.stringify({ productId: data.addTargetProductId, quantity: addItemQuantity }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      tags: { name: 'cart_cqrs_cqrs_add' },
+    }
+  );
+
+  recordAddResult(
+    response,
+    cqrsAddDuration,
+    cqrsAddRequests,
+    cqrsAddFailures,
+    cqrsAddSuccessRate,
+    data.addTargetProductId
+  );
+}
+
+export function syncAddDelay(data) {
+  const memberId = pickMemberId(data.syncAddDelayMemberIds);
+  const response = http.post(
+    `${marketExperimentBaseUrl}/api/v1/experiments/cart-cqrs/baseline/add/${memberId}?productDelayMs=${productDelayMs}`,
+    JSON.stringify({ productId: data.addTargetProductId, quantity: addItemQuantity }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      tags: { name: 'cart_cqrs_sync_add_delay' },
+    }
+  );
+
+  recordAddResult(
+    response,
+    syncAddDelayDuration,
+    syncAddDelayRequests,
+    syncAddDelayFailures,
+    syncAddDelaySuccessRate,
+    data.addTargetProductId
+  );
+}
+
+export function cqrsAddDelay(data) {
+  const memberId = pickMemberId(data.cqrsAddDelayMemberIds);
+  const response = http.post(
+    `${marketExperimentBaseUrl}/api/v1/experiments/cart-cqrs/cqrs/add/${memberId}`,
+    JSON.stringify({ productId: data.addTargetProductId, quantity: addItemQuantity }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      tags: { name: 'cart_cqrs_cqrs_add_delay' },
+    }
+  );
+
+  recordAddResult(
+    response,
+    cqrsAddDelayDuration,
+    cqrsAddDelayRequests,
+    cqrsAddDelayFailures,
+    cqrsAddDelaySuccessRate,
+    data.addTargetProductId
+  );
+}
+
+export function handleSummary(data) {
+  const summaryPath = __ENV.SUMMARY_PATH || `/results/cart-cqrs-experiment-${runId}.json`;
+  const scenarioSeconds = parseDurationToSeconds(scenarioDuration);
+
+  return {
+    stdout: [
+      '',
+      `experiment=cart-cqrs`,
+      `run_id=${runId}`,
+      `product_delay_ms=${productDelayMs}`,
+      formatScenarioSummary(data, 'sync_read', scenarioSeconds),
+      formatScenarioSummary(data, 'cqrs_read', scenarioSeconds),
+      formatScenarioSummary(data, 'sync_read_delay', scenarioSeconds),
+      formatScenarioSummary(data, 'cqrs_read_delay', scenarioSeconds),
+      formatScenarioSummary(data, 'sync_add', scenarioSeconds),
+      formatScenarioSummary(data, 'cqrs_add', scenarioSeconds),
+      formatScenarioSummary(data, 'sync_add_delay', scenarioSeconds),
+      formatScenarioSummary(data, 'cqrs_add_delay', scenarioSeconds),
+      `read_avg_improvement_pct=${formatPercentDifference(metricAvg(data, 'cart_cqrs_sync_read_duration'), metricAvg(data, 'cart_cqrs_cqrs_read_duration'))}`,
+      `read_delay_avg_improvement_pct=${formatPercentDifference(metricAvg(data, 'cart_cqrs_sync_read_delay_duration'), metricAvg(data, 'cart_cqrs_cqrs_read_delay_duration'))}`,
+      `add_avg_improvement_pct=${formatPercentDifference(metricAvg(data, 'cart_cqrs_sync_add_duration'), metricAvg(data, 'cart_cqrs_cqrs_add_duration'))}`,
+      `add_delay_avg_improvement_pct=${formatPercentDifference(metricAvg(data, 'cart_cqrs_sync_add_delay_duration'), metricAvg(data, 'cart_cqrs_cqrs_add_delay_duration'))}`,
+      '',
+    ].join('\n'),
+    [summaryPath]: JSON.stringify(data, null, 2),
+  };
+}
+
+function makeScenario(execName, slotIndex) {
+  return {
+    executor: 'constant-vus',
+    vus: scenarioVus,
+    duration: scenarioDuration,
+    gracefulStop: '0s',
+    exec: execName,
+    startTime: `${slotIndex * scenarioSlotSeconds}s`,
+  };
+}
+
+function pickMemberId(memberIds) {
+  const iteration = exec.scenario.iterationInTest;
+  return memberIds[iteration % memberIds.length];
+}
+
+function recordReadResult(response, durationMetric, requestCounter, failureCounter, successRate, expectedItemCount) {
+  requestCounter.add(1);
+  durationMetric.add(response.timings.duration);
+
+  const passed = check(response, {
+    'read status is 200': (res) => res.status === 200,
+    'read contains expected item count': (res) => {
+      if (res.status !== 200) {
+        return false;
+      }
+      const payload = res.json();
+      return payload && Array.isArray(payload.items) && payload.items.length >= expectedItemCount;
+    },
+  });
+
+  successRate.add(passed);
+  if (!passed) {
+    failureCounter.add(1);
+  }
+}
+
+function recordAddResult(response, durationMetric, requestCounter, failureCounter, successRate, expectedProductId) {
+  requestCounter.add(1);
+  durationMetric.add(response.timings.duration);
+
+  const passed = check(response, {
+    'add status is 200': (res) => res.status === 200,
+    'add returns expected product id': (res) => {
+      if (res.status !== 200) {
+        return false;
+      }
+      const payload = res.json();
+      return payload && payload.productId === expectedProductId;
+    },
+  });
+
+  successRate.add(passed);
+  if (!passed) {
+    failureCounter.add(1);
+  }
+}
+
+function formatScenarioSummary(data, scenarioName, scenarioSeconds) {
+  const prefix = `cart_cqrs_${scenarioName}`;
+  const requestCount = metricCount(data, `${prefix}_requests_total`);
+  const avg = metricAvg(data, `${prefix}_duration`);
+  const p95 = metricP95(data, `${prefix}_duration`);
+  const successRate = metricRate(data, `${prefix}_success_rate`);
+  const failures = metricCount(data, `${prefix}_failures_total`);
+  const throughput = scenarioSeconds > 0 ? requestCount / scenarioSeconds : 0;
+
+  return [
+    `${scenarioName}.requests=${requestCount}`,
+    `${scenarioName}.throughput=${formatNumber(throughput)}`,
+    `${scenarioName}.avg=${formatNumber(avg)}ms`,
+    `${scenarioName}.p95=${formatNumber(p95)}ms`,
+    `${scenarioName}.success_rate=${formatNumber(successRate)}`,
+    `${scenarioName}.failures=${failures}`,
+  ].join(' ');
+}
+
+function metricAvg(data, name) {
+  return metricValue(data, name, 'avg');
+}
+
+function metricP95(data, name) {
+  return metricValue(data, name, 'p(95)');
+}
+
+function metricCount(data, name) {
+  return metricValue(data, name, 'count');
+}
+
+function metricRate(data, name) {
+  return metricValue(data, name, 'rate');
+}
+
+function metricValue(data, name, key) {
+  if (!data.metrics[name] || !data.metrics[name].values) {
+    return 0;
+  }
+
+  return data.metrics[name].values[key] || 0;
+}
+
+function formatPercentDifference(beforeValue, afterValue) {
+  if (!beforeValue || beforeValue <= 0) {
+    return '0';
+  }
+  return formatNumber(((beforeValue - afterValue) / beforeValue) * 100);
+}
+
+function formatNumber(value) {
+  return Number(value || 0).toFixed(2);
+}
+
+function parseDurationToSeconds(rawDuration) {
+  if (!rawDuration) {
+    return 0;
+  }
+
+  const trimmed = `${rawDuration}`.trim();
+  if (trimmed.endsWith('ms')) {
+    return Number(trimmed.slice(0, -2)) / 1000;
+  }
+  if (trimmed.endsWith('s')) {
+    return Number(trimmed.slice(0, -1));
+  }
+  if (trimmed.endsWith('m')) {
+    return Number(trimmed.slice(0, -1)) * 60;
+  }
+  return Number(trimmed);
+}

--- a/loadtest/run-cart-cqrs-experiment.sh
+++ b/loadtest/run-cart-cqrs-experiment.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+RUN_ID="${RUN_ID:-$(date +%s)}"
+PRODUCT_EXPERIMENT_BASE_URL="${PRODUCT_EXPERIMENT_BASE_URL:-http://product-service:8082}"
+MARKET_EXPERIMENT_BASE_URL="${MARKET_EXPERIMENT_BASE_URL:-http://market-service:8083}"
+PRODUCT_HEALTH_URL="${PRODUCT_HEALTH_URL:-${PRODUCT_EXPERIMENT_BASE_URL}/actuator/health}"
+MARKET_HEALTH_URL="${MARKET_HEALTH_URL:-${MARKET_EXPERIMENT_BASE_URL}/actuator/health}"
+WAIT_MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS:-40}"
+WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS:-2}"
+WAIT_STABLE_SUCCESSES="${WAIT_STABLE_SUCCESSES:-3}"
+SUMMARY_PATH="${SUMMARY_PATH:-/results/cart-cqrs-experiment-${RUN_ID}.json}"
+
+wait_for_http() {
+  local url="$1"
+
+  docker compose --profile loadtest run --no-deps --rm \
+    -e WAIT_URL="${url}" \
+    -e WAIT_MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS}" \
+    -e WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS}" \
+    -e WAIT_STABLE_SUCCESSES="${WAIT_STABLE_SUCCESSES}" \
+    k6 run /scripts/wait-http.js
+}
+
+docker compose up -d mysql redis redpanda payment-service member-service api-gateway
+
+PRODUCT_SERVICE_PROFILES_ACTIVE=docker,experiment \
+MARKET_SERVICE_PROFILES_ACTIVE=docker,experiment \
+docker compose up -d --build product-service market-service
+
+wait_for_http "${PRODUCT_HEALTH_URL}"
+wait_for_http "${MARKET_HEALTH_URL}"
+
+cat <<EOF
+experiment=cart-cqrs
+run_id=${RUN_ID}
+scenario_vus=${K6_SCENARIO_VUS:-30}
+scenario_duration=${K6_SCENARIO_DURATION:-20s}
+scenario_slot_seconds=${K6_SCENARIO_SLOT_SECONDS:-25}
+product_count=${K6_PRODUCT_COUNT:-3}
+product_delay_ms=${K6_PRODUCT_DELAY_MS:-900}
+read_member_count=${K6_READ_MEMBER_COUNT:-50}
+add_member_count_per_scenario=${K6_ADD_MEMBER_COUNT_PER_SCENARIO:-100}
+summary_path=${SUMMARY_PATH}
+EOF
+
+docker compose --profile loadtest run --no-deps --rm \
+  -e RUN_ID="${RUN_ID}" \
+  -e PRODUCT_EXPERIMENT_BASE_URL="${PRODUCT_EXPERIMENT_BASE_URL}" \
+  -e MARKET_EXPERIMENT_BASE_URL="${MARKET_EXPERIMENT_BASE_URL}" \
+  -e SCENARIO_VUS="${K6_SCENARIO_VUS:-30}" \
+  -e SCENARIO_DURATION="${K6_SCENARIO_DURATION:-20s}" \
+  -e SCENARIO_SLOT_SECONDS="${K6_SCENARIO_SLOT_SECONDS:-25}" \
+  -e PRODUCT_COUNT="${K6_PRODUCT_COUNT:-3}" \
+  -e PRODUCT_STOCK="${K6_PRODUCT_STOCK:-100000}" \
+  -e PRODUCT_PRICE="${K6_PRODUCT_PRICE:-10000}" \
+  -e PRODUCT_SALE_PRICE="${K6_PRODUCT_SALE_PRICE:-9000}" \
+  -e READ_MEMBER_COUNT="${K6_READ_MEMBER_COUNT:-50}" \
+  -e ADD_MEMBER_COUNT_PER_SCENARIO="${K6_ADD_MEMBER_COUNT_PER_SCENARIO:-100}" \
+  -e READ_ITEM_QUANTITY="${K6_READ_ITEM_QUANTITY:-1}" \
+  -e ADD_ITEM_QUANTITY="${K6_ADD_ITEM_QUANTITY:-1}" \
+  -e PRODUCT_DELAY_MS="${K6_PRODUCT_DELAY_MS:-900}" \
+  -e BASE_MEMBER_ID="${K6_BASE_MEMBER_ID:-980000}" \
+  -e SUMMARY_PATH="${SUMMARY_PATH}" \
+  k6 run /scripts/cart-cqrs-experiment.js

--- a/market-service/src/main/java/com/thock/back/market/experiment/CartCqrsExperimentController.java
+++ b/market-service/src/main/java/com/thock/back/market/experiment/CartCqrsExperimentController.java
@@ -1,0 +1,62 @@
+package com.thock.back.market.experiment;
+
+import com.thock.back.market.in.dto.req.CartItemAddRequest;
+import com.thock.back.market.in.dto.res.CartItemListResponse;
+import com.thock.back.market.in.dto.res.CartItemResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Profile("experiment")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/experiments/cart-cqrs")
+public class CartCqrsExperimentController {
+
+    private final CartCqrsExperimentService cartCqrsExperimentService;
+
+    @PostMapping("/dataset/seed")
+    public ResponseEntity<CartCqrsExperimentDatasetResponse> seedDataset(
+            @Valid @RequestBody CartCqrsExperimentSeedRequest request
+    ) {
+        return ResponseEntity.ok(cartCqrsExperimentService.seedDataset(request));
+    }
+
+    @GetMapping("/baseline/read/{memberId}")
+    public ResponseEntity<CartItemListResponse> getBaselineCartItems(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "0") long productDelayMs
+    ) {
+        return ResponseEntity.ok(cartCqrsExperimentService.getBaselineCartItems(memberId, productDelayMs));
+    }
+
+    @GetMapping("/cqrs/read/{memberId}")
+    public ResponseEntity<CartItemListResponse> getCqrsCartItems(@PathVariable Long memberId) {
+        return ResponseEntity.ok(cartCqrsExperimentService.getCqrsCartItems(memberId));
+    }
+
+    @PostMapping("/baseline/add/{memberId}")
+    public ResponseEntity<CartItemResponse> addBaselineCartItem(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "0") long productDelayMs,
+            @Valid @RequestBody CartItemAddRequest request
+    ) {
+        return ResponseEntity.ok(cartCqrsExperimentService.addBaselineCartItem(memberId, request, productDelayMs));
+    }
+
+    @PostMapping("/cqrs/add/{memberId}")
+    public ResponseEntity<CartItemResponse> addCqrsCartItem(
+            @PathVariable Long memberId,
+            @Valid @RequestBody CartItemAddRequest request
+    ) {
+        return ResponseEntity.ok(cartCqrsExperimentService.addCqrsCartItem(memberId, request));
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/experiment/CartCqrsExperimentDatasetResponse.java
+++ b/market-service/src/main/java/com/thock/back/market/experiment/CartCqrsExperimentDatasetResponse.java
@@ -1,0 +1,15 @@
+package com.thock.back.market.experiment;
+
+import java.util.List;
+
+public record CartCqrsExperimentDatasetResponse(
+        Long baseMemberId,
+        List<Long> productIds,
+        Long addTargetProductId,
+        List<Long> readMemberIds,
+        List<Long> syncAddMemberIds,
+        List<Long> cqrsAddMemberIds,
+        List<Long> syncAddDelayMemberIds,
+        List<Long> cqrsAddDelayMemberIds
+) {
+}

--- a/market-service/src/main/java/com/thock/back/market/experiment/CartCqrsExperimentSeedRequest.java
+++ b/market-service/src/main/java/com/thock/back/market/experiment/CartCqrsExperimentSeedRequest.java
@@ -1,0 +1,14 @@
+package com.thock.back.market.experiment;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record CartCqrsExperimentSeedRequest(
+        Long baseMemberId,
+        @NotEmpty List<Long> productIds,
+        Integer readMemberCount,
+        Integer addMemberCountPerScenario,
+        Integer readItemQuantity,
+        Integer addItemQuantity
+) {
+}

--- a/market-service/src/main/java/com/thock/back/market/experiment/CartCqrsExperimentService.java
+++ b/market-service/src/main/java/com/thock/back/market/experiment/CartCqrsExperimentService.java
@@ -1,0 +1,299 @@
+package com.thock.back.market.experiment;
+
+import com.thock.back.global.exception.CustomException;
+import com.thock.back.global.exception.ErrorCode;
+import com.thock.back.market.app.CartService;
+import com.thock.back.market.app.MarketSupport;
+import com.thock.back.market.domain.Cart;
+import com.thock.back.market.domain.CartItem;
+import com.thock.back.market.domain.CartProductView;
+import com.thock.back.market.domain.CartProductViewRepository;
+import com.thock.back.market.domain.MarketMember;
+import com.thock.back.market.in.dto.req.CartItemAddRequest;
+import com.thock.back.market.in.dto.res.CartItemListResponse;
+import com.thock.back.market.in.dto.res.CartItemResponse;
+import com.thock.back.market.out.api.dto.ProductInfo;
+import com.thock.back.market.out.client.ProductCartCqrsExperimentClient;
+import com.thock.back.market.out.client.ProductClient;
+import com.thock.back.market.out.repository.CartRepository;
+import com.thock.back.market.out.repository.MarketMemberRepository;
+import com.thock.back.shared.member.domain.MemberRole;
+import com.thock.back.shared.member.domain.MemberState;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Profile("experiment")
+@RequiredArgsConstructor
+public class CartCqrsExperimentService {
+
+    private static final long DEFAULT_BASE_MEMBER_ID = 980_000L;
+    private static final int DEFAULT_READ_MEMBER_COUNT = 50;
+    private static final int DEFAULT_ADD_MEMBER_COUNT_PER_SCENARIO = 100;
+    private static final int DEFAULT_READ_ITEM_QUANTITY = 1;
+    private static final int DEFAULT_ADD_ITEM_QUANTITY = 1;
+
+    private final MarketMemberRepository marketMemberRepository;
+    private final CartRepository cartRepository;
+    private final CartProductViewRepository cartProductViewRepository;
+    private final ProductClient productClient;
+    private final ProductCartCqrsExperimentClient productCartCqrsExperimentClient;
+    private final MarketSupport marketSupport;
+    private final CartService cartService;
+
+    @Transactional
+    public CartCqrsExperimentDatasetResponse seedDataset(CartCqrsExperimentSeedRequest request) {
+        if (request == null || request.productIds() == null || request.productIds().isEmpty()) {
+            throw new CustomException(ErrorCode.CART_PRODUCT_INFO_NOT_FOUND);
+        }
+
+        long baseMemberId = request.baseMemberId() == null ? DEFAULT_BASE_MEMBER_ID : request.baseMemberId();
+        int readMemberCount = positiveOrDefault(request.readMemberCount(), DEFAULT_READ_MEMBER_COUNT);
+        int addMemberCountPerScenario = positiveOrDefault(
+                request.addMemberCountPerScenario(),
+                DEFAULT_ADD_MEMBER_COUNT_PER_SCENARIO
+        );
+        int readItemQuantity = positiveOrDefault(request.readItemQuantity(), DEFAULT_READ_ITEM_QUANTITY);
+
+        List<Long> productIds = request.productIds().stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        if (productIds.isEmpty()) {
+            throw new CustomException(ErrorCode.CART_PRODUCT_INFO_NOT_FOUND);
+        }
+
+        CartCqrsExperimentDatasetResponse dataset = buildDatasetPlan(baseMemberId, productIds, readMemberCount, addMemberCountPerScenario);
+
+        upsertCartProductViews(productIds);
+        prepareMembersAndCarts(dataset);
+        seedReadCarts(dataset.readMemberIds(), productIds, readItemQuantity);
+
+        return dataset;
+    }
+
+    @Transactional(readOnly = true)
+    public CartItemListResponse getBaselineCartItems(Long memberId, long productDelayMs) {
+        MarketMember member = marketSupport.findMemberById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_USER_NOT_FOUND));
+        Cart cart = marketSupport.findCartByBuyer(member)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
+
+        if (!cart.hasItems()) {
+            return new CartItemListResponse(cart.getId(), List.of(), 0, 0L, 0L, 0L);
+        }
+
+        List<Long> productIds = cart.getItems().stream()
+                .map(CartItem::getProductId)
+                .toList();
+
+        Map<Long, ProductInfo> productMap = fetchProducts(productIds, productDelayMs).stream()
+                .collect(Collectors.toMap(ProductInfo::getId, product -> product, (left, right) -> left, LinkedHashMap::new));
+
+        List<CartItemResponse> items = cart.getItems().stream()
+                .map(cartItem -> {
+                    ProductInfo product = productMap.get(cartItem.getProductId());
+                    if (product == null) {
+                        return null;
+                    }
+                    return CartItemResponse.from(cartItem, product);
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        return CartItemListResponse.from(cart, items);
+    }
+
+    @Transactional
+    public CartItemResponse addBaselineCartItem(Long memberId, CartItemAddRequest request, long productDelayMs) {
+        MarketMember member = marketSupport.findMemberById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_USER_NOT_FOUND));
+        Cart cart = marketSupport.findCartByBuyer(member)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
+
+        ProductInfo product = fetchProduct(request.productId(), productDelayMs);
+
+        int existingQuantity = cart.getItems().stream()
+                .filter(item -> item.getProductId().equals(request.productId()))
+                .mapToInt(CartItem::getQuantity)
+                .sum();
+
+        if (product.availableStock() < existingQuantity + request.quantity()) {
+            throw new CustomException(ErrorCode.CART_PRODUCT_OUT_OF_STOCK);
+        }
+
+        CartItem cartItem = cart.addItem(request.productId(), request.quantity());
+        return CartItemResponse.from(cartItem, product);
+    }
+
+    @Transactional(readOnly = true)
+    public CartItemListResponse getCqrsCartItems(Long memberId) {
+        return cartService.getCartItems(memberId);
+    }
+
+    @Transactional
+    public CartItemResponse addCqrsCartItem(Long memberId, CartItemAddRequest request) {
+        return cartService.addCartItem(memberId, request);
+    }
+
+    private CartCqrsExperimentDatasetResponse buildDatasetPlan(
+            long baseMemberId,
+            List<Long> productIds,
+            int readMemberCount,
+            int addMemberCountPerScenario
+    ) {
+        long currentMemberId = baseMemberId;
+
+        List<Long> readMemberIds = range(currentMemberId, readMemberCount);
+        currentMemberId += readMemberCount;
+
+        List<Long> syncAddMemberIds = range(currentMemberId, addMemberCountPerScenario);
+        currentMemberId += addMemberCountPerScenario;
+
+        List<Long> cqrsAddMemberIds = range(currentMemberId, addMemberCountPerScenario);
+        currentMemberId += addMemberCountPerScenario;
+
+        List<Long> syncAddDelayMemberIds = range(currentMemberId, addMemberCountPerScenario);
+        currentMemberId += addMemberCountPerScenario;
+
+        List<Long> cqrsAddDelayMemberIds = range(currentMemberId, addMemberCountPerScenario);
+
+        return new CartCqrsExperimentDatasetResponse(
+                baseMemberId,
+                productIds,
+                productIds.get(0),
+                readMemberIds,
+                syncAddMemberIds,
+                cqrsAddMemberIds,
+                syncAddDelayMemberIds,
+                cqrsAddDelayMemberIds
+        );
+    }
+
+    private void prepareMembersAndCarts(CartCqrsExperimentDatasetResponse dataset) {
+        for (Long memberId : allMemberIds(dataset)) {
+            MarketMember member = ensureExperimentMember(memberId);
+            Cart cart = ensureCart(member);
+            if (cart.hasItems()) {
+                cart.clearItems();
+            }
+        }
+    }
+
+    private void seedReadCarts(List<Long> readMemberIds, List<Long> productIds, int quantity) {
+        for (Long memberId : readMemberIds) {
+            Cart cart = cartRepository.findById(memberId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
+
+            for (Long productId : productIds) {
+                cart.addItem(productId, quantity);
+            }
+        }
+    }
+
+    private void upsertCartProductViews(List<Long> productIds) {
+        Map<Long, CartProductView> existingViews = cartProductViewRepository.findAllByProductIdIn(productIds).stream()
+                .collect(Collectors.toMap(CartProductView::getProductId, view -> view));
+
+        List<CartProductView> upsertTargets = new ArrayList<>();
+        for (ProductInfo product : productClient.getProducts(productIds)) {
+            CartProductView existing = existingViews.get(product.getId());
+            if (existing == null) {
+                upsertTargets.add(new CartProductView(
+                        product.getId(),
+                        product.getSellerId(),
+                        product.getName(),
+                        product.getImageUrl(),
+                        product.getPrice(),
+                        product.getSalePrice(),
+                        product.getStock(),
+                        product.getReservedStock(),
+                        product.getState(),
+                        false
+                ));
+                continue;
+            }
+
+            existing.sync(
+                    product.getSellerId(),
+                    product.getName(),
+                    product.getImageUrl(),
+                    product.getPrice(),
+                    product.getSalePrice(),
+                    product.getStock(),
+                    product.getReservedStock(),
+                    product.getState(),
+                    false
+            );
+            upsertTargets.add(existing);
+        }
+
+        cartProductViewRepository.saveAll(upsertTargets);
+        cartProductViewRepository.flush();
+    }
+
+    private List<ProductInfo> fetchProducts(List<Long> productIds, long productDelayMs) {
+        if (productDelayMs > 0) {
+            return productCartCqrsExperimentClient.getProducts(productDelayMs, productIds);
+        }
+        return productClient.getProducts(productIds);
+    }
+
+    private ProductInfo fetchProduct(Long productId, long productDelayMs) {
+        List<ProductInfo> products = fetchProducts(List.of(productId), productDelayMs);
+        return products.stream()
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_PRODUCT_INFO_NOT_FOUND));
+    }
+
+    private MarketMember ensureExperimentMember(Long memberId) {
+        return marketMemberRepository.findById(memberId)
+                .orElseGet(() -> marketMemberRepository.save(new MarketMember(
+                        "cart-cqrs-experiment-" + memberId + "@example.com",
+                        "cart-cqrs-experiment-" + memberId,
+                        MemberRole.USER,
+                        MemberState.ACTIVE,
+                        memberId,
+                        LocalDateTime.now(),
+                        LocalDateTime.now()
+                )));
+    }
+
+    private Cart ensureCart(MarketMember member) {
+        return cartRepository.findById(member.getId())
+                .orElseGet(() -> cartRepository.save(new Cart(member)));
+    }
+
+    private List<Long> allMemberIds(CartCqrsExperimentDatasetResponse dataset) {
+        List<Long> memberIds = new ArrayList<>();
+        memberIds.addAll(dataset.readMemberIds());
+        memberIds.addAll(dataset.syncAddMemberIds());
+        memberIds.addAll(dataset.cqrsAddMemberIds());
+        memberIds.addAll(dataset.syncAddDelayMemberIds());
+        memberIds.addAll(dataset.cqrsAddDelayMemberIds());
+        return memberIds;
+    }
+
+    private List<Long> range(long startInclusive, int size) {
+        List<Long> values = new ArrayList<>(size);
+        for (int index = 0; index < size; index++) {
+            values.add(startInclusive + index);
+        }
+        return values;
+    }
+
+    private int positiveOrDefault(Integer value, int defaultValue) {
+        return value == null || value <= 0 ? defaultValue : value;
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/out/client/ProductCartCqrsExperimentClient.java
+++ b/market-service/src/main/java/com/thock/back/market/out/client/ProductCartCqrsExperimentClient.java
@@ -1,0 +1,23 @@
+package com.thock.back.market.out.client;
+
+import com.thock.back.market.config.FeignConfig;
+import com.thock.back.market.out.api.dto.ProductInfo;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+        name = "product-cart-cqrs-experiment-client",
+        url = "${custom.global.productServiceUrl}/api/v1/experiments/cart-cqrs/internal/products",
+        configuration = FeignConfig.class
+)
+public interface ProductCartCqrsExperimentClient {
+
+    @PostMapping("/list")
+    List<ProductInfo> getProducts(
+            @RequestParam long delayMs,
+            @RequestBody List<Long> productIds
+    );
+}

--- a/product-service/src/main/java/com/thock/back/product/experiment/ProductCartCqrsExperimentController.java
+++ b/product-service/src/main/java/com/thock/back/product/experiment/ProductCartCqrsExperimentController.java
@@ -1,0 +1,31 @@
+package com.thock.back.product.experiment;
+
+import com.thock.back.product.in.dto.internal.ProductInternalResponse;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Profile("experiment")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/experiments/cart-cqrs/internal/products")
+public class ProductCartCqrsExperimentController {
+
+    private final ProductCartCqrsExperimentService productCartCqrsExperimentService;
+
+    @PostMapping("/list")
+    public ResponseEntity<List<ProductInternalResponse>> getProductsByIds(
+            @RequestParam(defaultValue = "0") long delayMs,
+            @RequestBody @NotEmpty List<@NotNull Long> productIds
+    ) {
+        return ResponseEntity.ok(productCartCqrsExperimentService.getProductsByIds(productIds, delayMs));
+    }
+}

--- a/product-service/src/main/java/com/thock/back/product/experiment/ProductCartCqrsExperimentService.java
+++ b/product-service/src/main/java/com/thock/back/product/experiment/ProductCartCqrsExperimentService.java
@@ -1,0 +1,36 @@
+package com.thock.back.product.experiment;
+
+import com.thock.back.product.app.ProductQueryService;
+import com.thock.back.product.in.dto.internal.ProductInternalResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Profile("experiment")
+@RequiredArgsConstructor
+public class ProductCartCqrsExperimentService {
+
+    private final ProductQueryService productQueryService;
+
+    @Transactional(readOnly = true)
+    public List<ProductInternalResponse> getProductsByIds(List<Long> productIds, long delayMs) {
+        applyDelay(delayMs);
+        return productQueryService.getProductsByIds(productIds);
+    }
+
+    private void applyDelay(long delayMs) {
+        if (delayMs <= 0) {
+            return;
+        }
+
+        try {
+            Thread.sleep(delayMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while delaying cart CQRS experiment", e);
+        }
+    }
+}


### PR DESCRIPTION
> PR 제목 형식: `[BUG|FEAT|TASK|TEST] #이슈번호 작업요약`

## 관련 이슈
Closes #57 

## 변경 내용
- `market-service`에 장바구니 조회/생성 sync 경로와 CQRS 경로를 비교할 수 있는 실험용 엔드포인트를 추가했습니다.
- `product-service`에 내부 상품 조회 지연 주입용 실험 엔드포인트를 추가했습니다.
- 같은 조건 비교를 위한 실험 데이터셋 시드 로직을 추가했습니다.
- k6 단일 스크립트와 실행 스크립트를 추가해 조회/생성, 지연 주입 여부를 포함한 8개 시나리오를 한 번에 측정할 수 있도록 구성했습니다.
- `loadtest/README.md`에 실행 방법과 결과 확인 방법을 정리했습니다.

## 확인 내용
- `./gradlew :product-service:compileJava :market-service:compileJava` 통과
- k6 smoke run으로 조회/생성 Before/After 및 지연 주입 시나리오가 모두 실행되는 것을 확인
- 3회 반복 부하 실험 결과를 바탕으로 CQRS 적용 전후 성능 차이와 상품 서비스 의존 제거 효과를 정리할 수 있는 환경이 준비됐습니다.