### PR TITLE
[TEST] Product Outbox Before/After 장애 복구 실험 환경 추가

### DIFF
--- a/docs/product-outbox-before-after-analysis.md
+++ b/docs/product-outbox-before-after-analysis.md
@@ -1,0 +1,347 @@
+# Product Outbox Before/After Experiment Analysis
+
+## 1. 실험 목적
+
+이 실험은 상품 변경 이벤트 발행 방식을 아래 두 구조로 비교하기 위해 설계했다.
+
+- BEFORE: DB 커밋 후 Kafka로 바로 발행하는 `Direct Kafka`
+- AFTER: DB 커밋과 Outbox 적재를 함께 수행한 뒤 poller가 발행하는 `Outbox`
+
+검증하고자 한 핵심은 세 가지다.
+
+- broker 장애 시 커밋된 데이터 기준으로 이벤트 유실이 발생하는가
+- Outbox가 `PENDING -> SENT`로 실제 복구되는가
+- Outbox가 유실은 없애지만 duplicate publish 가능성은 남기는가
+
+즉 이 실험은 단순한 create API 성능 비교가 아니라, **Kafka broker 장애 상황에서 direct 발행과 outbox 발행의 신뢰성 차이**를 검증하는 실험이다.
+
+## 2. 비교 대상
+
+### BEFORE: Direct Kafka
+
+- 상품 생성 트랜잭션이 커밋된 뒤 `afterCommit()`에서 Kafka로 바로 발행
+- 별도의 durable retry state 없음
+- Kafka publish 실패 시 DB에 남은 상품 row와 Kafka event 사이를 다시 맞출 근거가 없음
+
+### AFTER: Outbox
+
+- 상품 생성과 Outbox row 적재를 단일 트랜잭션으로 묶음
+- broker 장애 시 `product_outbox_event`에 `PENDING`으로 남음
+- broker 복구 후 poller가 재시도해 `SENT`로 수렴
+
+## 3. 테스트 조건
+
+공통 조건은 아래와 같다.
+
+- 외부 상품 생성 요청: `2,400건`
+- 동시 사용자: `50 VUs`
+- 상품 재고: `5`
+- Kafka broker: 생성 요청 동안 down 상태 유지
+- 비교 기준: 동일 장애 조건의 Before/After
+- 최종 비교 run: `1776235550`
+
+### BEFORE 실행 조건
+
+- publish mode: `direct`
+- broker down 상태에서 상품 생성 요청 수행
+- product-service 재기동 후 broker 복구
+
+### AFTER 실행 조건
+
+- publish mode: `outbox`
+- broker down 상태에서 상품 생성 요청 수행
+- 복구 전 `PENDING` 누적 확인
+- broker 복구 후 poller 수렴 확인
+
+## 4. Direct Kafka에서 적용한 실무적 완화책
+
+이번 BEFORE는 "아무 조치도 하지 않은 direct"가 아니다. 운영에서 direct Kafka를 유지하려고 할 때 먼저 시도할 수 있는 완화책을 넣은 상태로 비교했다.
+
+적용한 내용은 아래와 같다.
+
+- **producer metadata warm-up**
+  - broker가 살아있는 상태에서 사전 1건 발행을 수행해 producer metadata를 미리 채움
+  - 목적: broker down 직후 첫 send 메타데이터 조회 비용 때문에 요청 경로가 바로 무너지는 상황 완화
+
+- **afterCommit 비동기 offload**
+  - `afterCommit()`에서 Kafka send를 request thread에서 직접 실행하지 않고 별도 executor로 위임
+  - 목적: broker 장애가 request thread를 직접 붙잡는 정도 완화
+
+- **짧은 direct producer timeout**
+  - `request.timeout.ms = 100`
+  - `delivery.timeout.ms = 200`
+  - `max.block.ms = 10`
+  - 목적: direct send가 오래 block되며 HTTP 요청 전체를 끌고 가지 않도록 제한
+
+실험 wrapper에 기록된 direct baseline 설정값은 아래와 같다.
+
+- `beforeDirectAsyncAfterCommitEnabled = true`
+- `beforeDirectWarmupEnabled = true`
+- `beforeDirectKafkaRequestTimeoutMs = 100`
+- `beforeDirectKafkaDeliveryTimeoutMs = 200`
+- `beforeDirectKafkaMaxBlockMs = 10`
+
+## 5. 왜 그래도 Direct Kafka는 정답이 아닌가
+
+위 완화책은 **요청 경로를 버티게 만드는 완충책**일 뿐, 이벤트 유실 문제 자체를 해결하지 못한다.
+
+핵심 이유는 direct 구조가 아래 성질을 가지기 때문이다.
+
+- DB commit은 이미 끝난 뒤 Kafka publish를 시도한다
+- publish 실패 시 재시도할 durable state가 없다
+- 따라서 "어떤 row는 DB에 커밋됐는데 어떤 event는 발행되지 않았다"는 불일치를 나중에 복구할 근거가 없다
+
+즉 direct Kafka에서 할 수 있는 최선은:
+
+- 요청 실패/지연을 줄이는 것
+- send 실패를 빨리 감지하는 것
+
+까지다.
+
+하지만 **이벤트 유실 0건 보장**은 할 수 없다.
+
+이 지점에서 Outbox가 필요한 이유가 나온다.
+
+## 6. 부하는 어떻게 주었는가
+
+실행 스크립트는 아래다.
+
+- `loadtest/run-product-outbox-before-after-experiment.sh`
+- 실제 부하 생성 스크립트: `loadtest/product-outbox-recovery.js`
+
+이번 실험에서 Kafka에 이벤트 `2,400건`을 직접 넣는 것은 아니다.
+
+입력은 **외부 상품 생성 요청 `2,400건`** 이다.
+
+구체적으로는 `k6`가 아래 조건으로 동작한다.
+
+- scenario executor: `shared-iterations`
+- 총 iteration 수: `2,400`
+- 동시 사용자: `50 VUs`
+- 각 iteration에서 `POST /api/v1/products/create` 1회 호출
+
+즉 부하 생성 수단은:
+
+- `k6`가 API Gateway를 통해 상품 생성 요청을 `2,400건` 보냄
+- 각 성공 요청이 상품 row 1건과 `product.changed` 이벤트 후보 1건을 만든다
+
+따라서 이번 실험의 기대 단위는 아래처럼 맞춰진다.
+
+- 외부 요청 `2,400건`
+- DB 상품 row 최대 `2,400건`
+- Kafka event 최대 `2,400건`
+
+흐름은 다음과 같다.
+
+1. 공통 인프라와 `product-service`를 `experiment` 프로필로 올림
+2. BEFORE direct 모드로 시작
+3. direct warm-up 1건 수행
+4. broker를 내린 뒤 외부 상품 생성 요청 `2,400건` 수행
+5. direct 결과 수집
+6. AFTER outbox 모드로 다시 시작
+7. broker를 내린 뒤 외부 상품 생성 요청 `2,400건` 수행
+8. 복구 전 outbox 상태 수집
+9. broker 복구 후 `PENDING -> SENT` 수렴 확인
+10. BEFORE/AFTER를 하나의 JSON으로 저장
+
+즉 한 번의 wrapper 실행으로:
+
+- direct under outage
+- outbox under outage + recovery
+
+를 모두 수집한다.
+
+## 7. 측정 기준
+
+이번 실험에서 보는 값은 단순 HTTP latency가 아니다. 핵심은 **run_id 기준으로 이번 실험에 의해 만들어진 상품 row와 Kafka 메시지를 서로 대응시키는 것**이다.
+
+### 7-1. DB 기준 집계
+
+wrapper는 `products.name LIKE 'k6-<run_id>-%'` 조건으로 이번 run에서 실제 커밋된 상품 row 수를 센다.
+
+이 값이:
+
+- `dbProductsCreated`
+
+이다.
+
+즉 "요청이 몇 건 들어왔는가"가 아니라, **DB에 실제로 남은 상품 row가 몇 건인가**를 기준으로 본다.
+
+### 7-2. Kafka topic 기준 집계
+
+wrapper는 실험 시작 전에 topic offset을 먼저 기록한다.
+
+그 다음 `loadtest/run-scoped-topic-stats.sh`가:
+
+- 이번 run에서 생성된 상품 ID 목록을 DB에서 조회하고
+- 시작 offset 이후의 `product.changed` 메시지 key를 읽은 뒤
+- 상품 ID와 메시지 key를 매칭한다
+
+이렇게 계산한 값이 아래다.
+
+- `matchedTopicMessages`
+  - 이번 run 상품과 매칭된 topic 메시지 총 수
+- `matchedUniqueProducts`
+  - 고유 product 기준으로 Kafka에 반영된 수
+- `duplicateTopicMessages`
+  - 같은 product에 대해 topic에 중복으로 들어간 수
+- `unrelatedTopicMessages`
+  - 이번 run과 무관한 메시지 수
+
+즉 Kafka 쪽 핵심 판단 기준은:
+
+- **고유 product 기준으로 몇 건이 실제 topic에 반영되었는가**
+
+이고, 그 값이 `matchedUniqueProducts`다.
+
+### 7-3. Outbox 기준 집계
+
+AFTER에서는 `product_outbox_event`를 이번 run의 상품 row와 join해서 상태를 직접 센다.
+
+핵심 값은 아래다.
+
+- `pendingCount`
+- `sentCount`
+- `failedCount`
+
+따라서:
+
+- broker down 동안 실제로 `PENDING`이 누적됐는지
+- broker 복구 후 `SENT`로 수렴했는지
+
+를 확인할 수 있다.
+
+### 7-4. 최종 비교 지표
+
+최종적으로는 아래 값을 비교한다.
+
+- `dbProductsCreated`
+  - DB에 실제 커밋된 상품 row 수
+- `matchedUniqueProducts`
+  - Kafka topic에서 고유 product 기준으로 확인된 이벤트 수
+- `missingPublishedEvent`
+  - `dbProductsCreated - matchedUniqueProducts`
+- `pendingCount`
+  - 복구 전 `product_outbox_event`의 `PENDING` row 수
+- `sentCount`
+  - 복구 후 `product_outbox_event`의 `SENT` row 수
+- `duplicateTopicMessages`
+  - topic에 들어간 전체 메시지 수와 고유 product 수의 차이
+- `recovery.durationMillis`
+  - broker 복구 시작부터 outbox가 모두 `SENT`로 수렴할 때까지 걸린 시간
+
+가장 중요한 계산식은 아래다.
+
+- `missingPublishedEvent = dbProductsCreated - matchedUniqueProducts`
+
+즉 이번 실험은:
+
+- **외부 상품 생성 요청 2,400건**
+  - 가 들어오면
+- **DB에 몇 건이 실제로 커밋됐는지**
+- **그중 몇 건이 Kafka topic에 고유 이벤트로 반영됐는지**
+- **Outbox는 복구 전후 상태가 어떻게 바뀌는지**
+
+를 run_id 기준으로 연결해서 비교하는 구조다.
+
+핵심 비교 기준은 아래 식으로 이해하면 된다.
+
+- **Direct no-loss 여부**
+  - `missingPublishedEvent == 0` 인가
+- **Outbox recovery 여부**
+  - 복구 전 `pendingCount > 0`
+  - 복구 후 `pendingCount == 0 && sentCount == dbProductsCreated`
+- **Outbox duplicate 여부**
+  - `duplicateTopicMessages > 0` 인가
+
+## 8. 최종 결과
+
+기준 run:
+
+- `1776235550`
+
+결과는 아래와 같다.
+
+| 항목 | BEFORE (`Direct Kafka`) | AFTER (`Outbox`) |
+|---|---:|---:|
+| DB 생성 수 | 2400 | 2400 |
+| 토픽 고유 반영 수 | 0 | 2400 |
+| 이벤트 유실 수 | 2400 | 0 |
+| 복구 전 PENDING 수 | - | 2400 |
+| 복구 후 SENT 수 | - | 2400 |
+| 중복 발행 수 | - | 50 |
+| 복구 시간 | - | 47000ms |
+
+해석:
+
+- direct는 broker 장애 시 **커밋된 2,400건 모두 이벤트 유실**
+- outbox는 동일 조건에서 **복구 후 2,400건 모두 발행되어 유실 0건**
+- 다만 outbox는 `at-least-once` 특성상 **duplicate publish 50건**이 발생
+
+즉 이 실험은 아래를 증명한다.
+
+- direct Kafka는 best-effort tuning을 해도 no-loss를 보장하지 못한다
+- outbox는 no-loss를 달성한다
+- 대신 duplicate 가능성이 남으므로 **Inbox/idempotency와 함께 가야 한다**
+
+## 9. 왜 duplicate 50건이 중요한가
+
+이번 결과에서 `duplicateTopicMessages = 50`은 오히려 좋은 학습 포인트다.
+
+이 값은:
+
+- outbox가 유실은 없앴지만
+- 발행 보장은 `exactly-once`가 아니라 `at-least-once`
+
+라는 점을 드러낸다.
+
+따라서 아키텍처 메시지는 이렇게 정리된다.
+
+- Outbox: **유실 방지**
+- Inbox / idempotency: **중복 소비 차단**
+
+즉 Outbox 슬라이드 다음에 Inbox 슬라이드가 자연스럽게 이어진다.
+
+## 10. 면접에서 설명할 때의 핵심 문장
+
+짧게 설명하면 아래가 가장 정확하다.
+
+> direct Kafka는 DB 커밋 후 Kafka로 바로 발행하기 때문에 broker 장애 시 커밋된 row와 발행된 이벤트 사이를 나중에 복구할 durable state가 없습니다. 그래서 producer timeout, metadata warm-up, afterCommit 비동기 offload 같은 완화책을 적용해도 유실 자체는 막지 못했습니다. 반면 Outbox는 상품 생성과 Outbox 적재를 한 트랜잭션으로 묶어 broker 장애 시 `PENDING`으로 남기고, 복구 후 poller가 `SENT`로 수렴시켜 유실 0건을 만들 수 있었습니다.
+
+duplicate까지 이어서 설명하면 아래 정도면 충분하다.
+
+> 다만 Outbox는 exactly-once가 아니라 at-least-once 발행이라 duplicate publish 가능성이 남습니다. 이번 실험에서도 duplicate 50건이 나왔고, 그래서 다음 단계로 Inbox 기반 idempotency를 적용했습니다.
+
+## 11. 이 실험이 증명하는 것과 증명하지 않는 것
+
+### 증명하는 것
+
+- broker 장애 시 direct와 outbox의 **유실 차이**
+- outbox의 **복구 가능성**
+- outbox의 **at-least-once 성격**
+
+### 증명하지 않는 것
+
+- direct와 outbox의 일반적인 create API latency 비교
+- Kafka exactly-once delivery 보장
+- 소비 측 duplicate 처리 완결성
+
+duplicate 소비 차단은 별도 Inbox 실험으로 봐야 한다.
+
+## 12. 실행 방법
+
+실행 스크립트:
+
+- `loadtest/run-product-outbox-before-after-experiment.sh`
+
+실행 예시:
+
+```bash
+RUN_ID=$(date +%s) bash loadtest/run-product-outbox-before-after-experiment.sh
+```
+
+결과 파일:
+
+- `loadtest/results/product-outbox-before-after-<run_id>.json`
+
+이 JSON 하나로 BEFORE/AFTER 비교표를 만들 수 있다.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -201,6 +201,71 @@ Key result fields:
 - `improvements.throughputEventsPerSecondPct`
 - `improvements.totalDurationMsPct`
 
+Run the Outbox recovery experiment with one wrapper.
+
+```bash
+bash loadtest/run-product-outbox-recovery-experiment.sh
+```
+
+This wrapper runs a fixed-iteration product create load while `redpanda` is stopped, then restarts `product-service` after broker recovery and measures how fast run-scoped outbox rows converge from `PENDING` to `SENT`.
+
+Flow:
+
+- start stack in `outbox` publish mode
+- capture `product.changed` start offset
+- stop `redpanda`
+- run fixed-iteration product create load
+- verify run-scoped outbox rows accumulated as `PENDING`
+- start `redpanda` again
+- restart `product-service`
+- poll until run-scoped outbox rows are fully `SENT` and topic messages match created product rows
+
+Useful overrides:
+
+- `RUN_ID=1778000000`
+- `K6_ITERATIONS=2400`
+- `K6_VUS=50`
+- `K6_STOCK=5`
+- `PRODUCT_OUTBOX_POLLER_INTERVAL_MS=1000`
+- `RECOVERY_POLL_INTERVAL_SECONDS=1`
+- `RECOVERY_POLL_TIMEOUT_SECONDS=300`
+
+Key result fields:
+
+- `beforeRecovery.dbProductsCreated`
+- `beforeRecovery.pendingCount`
+- `afterRecovery.sentCount`
+- `afterRecovery.matchedUniqueProducts`
+- `afterRecovery.missingPublishedEvent`
+- `recovery.durationMillis`
+- `validations.pendingAccumulatedBeforeRecovery`
+- `validations.allOutboxSentAfterRecovery`
+- `validations.noEventLoss`
+
+Run the direct-vs-outbox reliability comparison with one wrapper.
+
+```bash
+bash loadtest/run-product-outbox-before-after-experiment.sh
+```
+
+This wrapper runs two phases under the same fixed-iteration create load:
+
+- `before`: `direct` publish mode + broker down during create + `product-service` restart before broker recovery
+- `after`: `outbox` publish mode + broker down during create + broker recovery + `product-service` restart
+
+Key comparison fields:
+
+- `before.dbProductsCreated`
+- `before.matchedUniqueProducts`
+- `before.missingPublishedEvent`
+- `after.beforeRecovery.pendingCount`
+- `after.afterRecovery.sentCount`
+- `after.afterRecovery.matchedUniqueProducts`
+- `after.afterRecovery.missingPublishedEvent`
+- `after.recovery.durationMillis`
+- `validations.beforeLostEventsDetected`
+- `validations.afterNoEventLoss`
+
 Reset the product experiment state cleanly before each run.
 
 ```bash

--- a/loadtest/prepare-seller-token.js
+++ b/loadtest/prepare-seller-token.js
@@ -1,0 +1,153 @@
+import http from 'k6/http';
+import { fail, sleep } from 'k6';
+
+const runId = __ENV.RUN_ID || `${Date.now()}`;
+
+export const options = {
+  scenarios: {
+    prepare_seller_token: {
+      executor: 'shared-iterations',
+      iterations: 1,
+      vus: 1,
+      maxDuration: '2m',
+      gracefulStop: '0s',
+    },
+  },
+};
+
+export default function () {
+  const baseUrl = (__ENV.BASE_URL || 'http://api-gateway:8080').replace(/\/$/, '');
+  const password = __ENV.PASSWORD || 'password123!';
+  const sellerEmail = `seller-k6-${runId}@example.com`;
+  const sellerName = `seller-k6-${runId}`;
+
+  signUp(baseUrl, sellerEmail, sellerName, password);
+  sleep(0.5);
+
+  const memberToken = login(baseUrl, sellerEmail, password);
+  promoteSeller(baseUrl, memberToken, sellerName);
+  sleep(0.5);
+
+  const sellerToken = login(baseUrl, sellerEmail, password);
+  console.log(`__SELLER_ACCESS_TOKEN__=${sellerToken}`);
+}
+
+function signUp(baseUrl, email, name, password) {
+  const response = requestWithRetry(() =>
+    http.post(
+      `${baseUrl}/api/v1/members/signup`,
+      JSON.stringify({ email, name, password }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        tags: { name: 'signup' },
+      }
+    ),
+    {
+      action: 'signup',
+      expectedStatuses: [201, 409],
+      retryOnStatuses: [500, 502, 503, 504],
+    }
+  );
+
+  if (response.status !== 201 && response.status !== 409) {
+    fail(`signup failed: status=${response.status} body=${response.body}`);
+  }
+}
+
+function login(baseUrl, email, password) {
+  const response = requestWithRetry(() =>
+    http.post(
+      `${baseUrl}/api/v1/auth/login`,
+      JSON.stringify({ email, password }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        tags: { name: 'login' },
+      }
+    ),
+    {
+      action: 'login',
+      expectedStatuses: [200],
+      retryOnStatuses: [500, 502, 503, 504],
+      maxAttempts: 6,
+      backoffSeconds: 1,
+    }
+  );
+
+  if (!response || response.status !== 200) {
+    fail(`login failed: status=${response.status} body=${response.body}`);
+  }
+
+  const payload = response.json();
+  if (!payload.accessToken) {
+    fail(`login response does not contain accessToken: body=${response.body}`);
+  }
+
+  return payload.accessToken;
+}
+
+function promoteSeller(baseUrl, accessToken, accountHolder) {
+  const response = requestWithRetry(() =>
+    http.patch(
+      `${baseUrl}/api/v1/members/role`,
+      JSON.stringify({
+        bankCode: __ENV.BANK_CODE || '088',
+        accountNumber: __ENV.ACCOUNT_NUMBER || '1234567890',
+        accountHolder: __ENV.ACCOUNT_HOLDER || accountHolder,
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        tags: { name: 'promote_seller' },
+      }
+    ),
+    {
+      action: 'promote seller',
+      expectedStatuses: [200, 409],
+      retryOnStatuses: [500, 502, 503, 504],
+      maxAttempts: 5,
+      backoffSeconds: 1,
+    }
+  );
+
+  if (response.status !== 200 && response.status !== 409) {
+    fail(`promote seller failed: status=${response.status} body=${response.body}`);
+  }
+}
+
+function requestWithRetry(requestFn, options = {}) {
+  const {
+    action = 'request',
+    expectedStatuses = [200],
+    retryOnStatuses = [500, 502, 503, 504],
+    maxAttempts = 5,
+    backoffSeconds = 0.5,
+  } = options;
+
+  let lastResponse = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    lastResponse = requestFn();
+
+    if (lastResponse && expectedStatuses.includes(lastResponse.status)) {
+      return lastResponse;
+    }
+
+    const shouldRetry =
+      !lastResponse ||
+      retryOnStatuses.includes(lastResponse.status) ||
+      lastResponse.error_code !== 0;
+
+    if (!shouldRetry || attempt === maxAttempts) {
+      return lastResponse;
+    }
+
+    console.warn(
+      `${action} retrying: attempt=${attempt} status=${lastResponse.status} error=${lastResponse.error}`
+    );
+    sleep(backoffSeconds * attempt);
+  }
+
+  return lastResponse;
+}

--- a/loadtest/product-outbox-recovery.js
+++ b/loadtest/product-outbox-recovery.js
@@ -1,0 +1,263 @@
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { check, fail, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+
+const productsCreated = new Counter('products_created_total');
+const productCreateFailures = new Counter('product_create_failures_total');
+const experimentRunId = __ENV.RUN_ID || `${Date.now()}`;
+
+const iterations = Number(__ENV.K6_ITERATIONS || 2400);
+const vus = Number(__ENV.K6_VUS || 50);
+const sleepBetween = Number(__ENV.SLEEP_BETWEEN || 0);
+const enforceCreateSuccess = (__ENV.ENFORCE_CREATE_SUCCESS || 'true') === 'true';
+const requestTimeout = __ENV.REQUEST_TIMEOUT || '180s';
+
+const thresholds = {};
+if (enforceCreateSuccess) {
+  thresholds.checks = ['rate>0.99'];
+  thresholds.product_create_failures_total = ['count==0'];
+}
+
+export const options = {
+  scenarios: {
+    product_outbox_recovery: {
+      executor: 'shared-iterations',
+      iterations,
+      vus,
+      maxDuration: __ENV.MAX_DURATION || '10m',
+      gracefulStop: '5s',
+    },
+  },
+  thresholds,
+};
+
+export function setup() {
+  const baseUrl = (__ENV.BASE_URL || 'http://api-gateway:8080').replace(/\/$/, '');
+  const password = __ENV.PASSWORD || 'password123!';
+  const runId = experimentRunId;
+
+  if (__ENV.SELLER_ACCESS_TOKEN) {
+    return {
+      accessToken: __ENV.SELLER_ACCESS_TOKEN,
+      baseUrl,
+      runId,
+    };
+  }
+
+  const sellerEmail = `seller-k6-${runId}@example.com`;
+  const sellerName = `seller-k6-${runId}`;
+
+  signUp(baseUrl, sellerEmail, sellerName, password);
+  sleep(0.5);
+
+  const memberToken = login(baseUrl, sellerEmail, password);
+  promoteSeller(baseUrl, memberToken, sellerName);
+  sleep(0.5);
+
+  const sellerToken = login(baseUrl, sellerEmail, password);
+
+  return {
+    accessToken: sellerToken,
+    baseUrl,
+    runId,
+  };
+}
+
+export default function (data) {
+  const productName = buildProductName(data.runId);
+  const price = Number(__ENV.PRICE || 1000);
+  const salePrice = Number(__ENV.SALE_PRICE || __ENV.PRICE || 1000);
+  const payload = JSON.stringify({
+    name: productName,
+    price,
+    salePrice,
+    stock: Number(__ENV.STOCK || 5),
+    category: __ENV.CATEGORY || 'KEYBOARD',
+    description: `k6 outbox recovery ${productName}`,
+    imageUrl: 'https://example.com/k6-product.png',
+    detail: {
+      source: 'k6',
+      runId: data.runId,
+    },
+  });
+
+  const response = http.post(`${data.baseUrl}/api/v1/products/create`, payload, {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${data.accessToken}`,
+    },
+    tags: {
+      name: 'create_product',
+      experiment: __ENV.EXPERIMENT_NAME || 'product-outbox-recovery',
+    },
+    timeout: requestTimeout,
+  });
+
+  const passed = check(response, {
+    'create product status is 201': (res) => res.status === 201,
+  });
+
+  if (passed) {
+    productsCreated.add(1);
+  } else {
+    productCreateFailures.add(1);
+  }
+
+  if (sleepBetween > 0) {
+    sleep(sleepBetween);
+  }
+}
+
+export function handleSummary(data) {
+  const summaryPath = __ENV.SUMMARY_PATH || '/results/product-outbox-recovery-summary.json';
+
+  return {
+    stdout: [
+      '',
+      `experiment=${__ENV.EXPERIMENT_NAME || 'product-outbox-recovery'}`,
+      `run_id=${experimentRunId}`,
+      `products_created_total=${formatMetricValue(data.metrics.products_created_total, 'count')}`,
+      `product_create_failures_total=${formatMetricValue(data.metrics.product_create_failures_total, 'count')}`,
+      `http_req_failed=${formatMetricValue(data.metrics.http_req_failed, 'rate')}`,
+      '',
+    ].join('\n'),
+    [summaryPath]: JSON.stringify(data, null, 2),
+  };
+}
+
+function signUp(baseUrl, email, name, password) {
+  const response = requestWithRetry(() =>
+    http.post(
+      `${baseUrl}/api/v1/members/signup`,
+      JSON.stringify({ email, name, password }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        tags: { name: 'signup' },
+      }
+    ),
+    {
+      action: 'signup',
+      expectedStatuses: [201, 409],
+      retryOnStatuses: [500, 502, 503, 504],
+    }
+  );
+
+  if (response.status !== 201 && response.status !== 409) {
+    fail(`signup failed: status=${response.status} body=${response.body}`);
+  }
+}
+
+function login(baseUrl, email, password) {
+  const response = requestWithRetry(() =>
+    http.post(
+      `${baseUrl}/api/v1/auth/login`,
+      JSON.stringify({ email, password }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+        tags: { name: 'login' },
+      }
+    ),
+    {
+      action: 'login',
+      expectedStatuses: [200],
+      retryOnStatuses: [500, 502, 503, 504],
+      maxAttempts: 6,
+      backoffSeconds: 1,
+    }
+  );
+
+  if (!response || response.status !== 200) {
+    fail(`login failed: status=${response.status} body=${response.body}`);
+  }
+
+  const payload = response.json();
+  if (!payload.accessToken) {
+    fail(`login response does not contain accessToken: body=${response.body}`);
+  }
+
+  return payload.accessToken;
+}
+
+function promoteSeller(baseUrl, accessToken, accountHolder) {
+  const response = requestWithRetry(() =>
+    http.patch(
+      `${baseUrl}/api/v1/members/role`,
+      JSON.stringify({
+        bankCode: __ENV.BANK_CODE || '088',
+        accountNumber: __ENV.ACCOUNT_NUMBER || '1234567890',
+        accountHolder: __ENV.ACCOUNT_HOLDER || accountHolder,
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        tags: { name: 'promote_seller' },
+      }
+    ),
+    {
+      action: 'promote seller',
+      expectedStatuses: [200, 409],
+      retryOnStatuses: [500, 502, 503, 504],
+      maxAttempts: 5,
+      backoffSeconds: 1,
+    }
+  );
+
+  if (response.status !== 200 && response.status !== 409) {
+    fail(`promote seller failed: status=${response.status} body=${response.body}`);
+  }
+}
+
+function requestWithRetry(requestFn, options = {}) {
+  const {
+    action = 'request',
+    expectedStatuses = [200],
+    retryOnStatuses = [500, 502, 503, 504],
+    maxAttempts = 5,
+    backoffSeconds = 0.5,
+  } = options;
+
+  let lastResponse = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    lastResponse = requestFn();
+
+    if (lastResponse && expectedStatuses.includes(lastResponse.status)) {
+      return lastResponse;
+    }
+
+    const shouldRetry =
+      !lastResponse ||
+      retryOnStatuses.includes(lastResponse.status) ||
+      lastResponse.error_code !== 0;
+
+    if (!shouldRetry || attempt === maxAttempts) {
+      return lastResponse;
+    }
+
+    console.warn(
+      `${action} retrying: attempt=${attempt} status=${lastResponse.status} error=${lastResponse.error}`
+    );
+    sleep(backoffSeconds * attempt);
+  }
+
+  return lastResponse;
+}
+
+function buildProductName(runId) {
+  return [
+    'k6',
+    runId,
+    exec.vu.idInTest,
+    exec.scenario.iterationInTest,
+  ].join('-');
+}
+
+function formatMetricValue(metric, key) {
+  if (!metric || !metric.values || metric.values[key] === undefined) {
+    return '0';
+  }
+  return String(metric.values[key]);
+}

--- a/loadtest/run-product-outbox-before-after-experiment.sh
+++ b/loadtest/run-product-outbox-before-after-experiment.sh
@@ -1,0 +1,488 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd jq
+
+RUN_ID="${RUN_ID:-$(date +%s)}"
+TOPIC="${TOPIC:-product.changed}"
+MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-root}"
+BASE_URL="${K6_BASE_URL:-http://api-gateway:8080}"
+PRODUCT_SERVICE_BASE_URL="${PRODUCT_SERVICE_BASE_URL:-http://product-service:8082}"
+PRODUCT_SERVICE_HEALTH_URL="${PRODUCT_SERVICE_HEALTH_URL:-${PRODUCT_SERVICE_BASE_URL}/actuator/health}"
+GATEWAY_HEALTH_URL="${GATEWAY_HEALTH_URL:-http://api-gateway:8080/actuator/health}"
+
+PRODUCT_SERVICE_PROFILES_ACTIVE="${PRODUCT_SERVICE_PROFILES_ACTIVE:-docker,experiment}"
+PRODUCT_OUTBOX_POLLER_INTERVAL_MS="${PRODUCT_OUTBOX_POLLER_INTERVAL_MS:-1000}"
+DIRECT_PRODUCT_KAFKA_REQUEST_TIMEOUT_MS="${DIRECT_PRODUCT_KAFKA_REQUEST_TIMEOUT_MS:-100}"
+DIRECT_PRODUCT_KAFKA_DELIVERY_TIMEOUT_MS="${DIRECT_PRODUCT_KAFKA_DELIVERY_TIMEOUT_MS:-200}"
+DIRECT_PRODUCT_KAFKA_MAX_BLOCK_MS="${DIRECT_PRODUCT_KAFKA_MAX_BLOCK_MS:-10}"
+AFTER_PRODUCT_KAFKA_REQUEST_TIMEOUT_MS="${AFTER_PRODUCT_KAFKA_REQUEST_TIMEOUT_MS:-1000}"
+AFTER_PRODUCT_KAFKA_DELIVERY_TIMEOUT_MS="${AFTER_PRODUCT_KAFKA_DELIVERY_TIMEOUT_MS:-2000}"
+AFTER_PRODUCT_KAFKA_MAX_BLOCK_MS="${AFTER_PRODUCT_KAFKA_MAX_BLOCK_MS:-1000}"
+DIRECT_ASYNC_AFTER_COMMIT_ENABLED="${DIRECT_ASYNC_AFTER_COMMIT_ENABLED:-true}"
+DIRECT_ASYNC_CORE_POOL_SIZE="${DIRECT_ASYNC_CORE_POOL_SIZE:-16}"
+DIRECT_ASYNC_MAX_POOL_SIZE="${DIRECT_ASYNC_MAX_POOL_SIZE:-32}"
+DIRECT_ASYNC_QUEUE_CAPACITY="${DIRECT_ASYNC_QUEUE_CAPACITY:-4000}"
+DIRECT_WARMUP_ENABLED="${DIRECT_WARMUP_ENABLED:-true}"
+DIRECT_WARMUP_ITERATIONS="${DIRECT_WARMUP_ITERATIONS:-1}"
+DIRECT_WARMUP_VUS="${DIRECT_WARMUP_VUS:-1}"
+
+K6_ITERATIONS="${K6_ITERATIONS:-2400}"
+K6_VUS="${K6_VUS:-50}"
+K6_STOCK="${K6_STOCK:-5}"
+K6_SLEEP_BETWEEN="${K6_SLEEP_BETWEEN:-0}"
+
+RECOVERY_POLL_INTERVAL_SECONDS="${RECOVERY_POLL_INTERVAL_SECONDS:-1}"
+RECOVERY_POLL_TIMEOUT_SECONDS="${RECOVERY_POLL_TIMEOUT_SECONDS:-300}"
+DIRECT_SETTLE_SECONDS="${DIRECT_SETTLE_SECONDS:-3}"
+PHASE_START_GRACE_SECONDS="${PHASE_START_GRACE_SECONDS:-3}"
+
+BEFORE_PHASE_RUN_ID="${RUN_ID}-before"
+AFTER_PHASE_RUN_ID="${RUN_ID}-after"
+DIRECT_WARMUP_RUN_ID="${RUN_ID}-direct-warmup"
+
+BEFORE_K6_SUMMARY_PATH="/results/product-outbox-before-${RUN_ID}-k6.json"
+AFTER_K6_SUMMARY_PATH="/results/product-outbox-after-${RUN_ID}-k6.json"
+RESULT_PATH="loadtest/results/product-outbox-before-after-${RUN_ID}.json"
+
+wait_for_http() {
+  local url="$1"
+  docker compose --profile loadtest run --no-deps --rm \
+    -e WAIT_URL="${url}" \
+    -e WAIT_MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS:-60}" \
+    -e WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS:-2}" \
+    -e WAIT_STABLE_SUCCESSES="${WAIT_STABLE_SUCCESSES:-3}" \
+    k6 run /scripts/wait-http.js >/dev/null
+}
+
+wait_for_redpanda() {
+  local max_attempts="${REDPANDA_WAIT_MAX_ATTEMPTS:-60}"
+  local sleep_seconds="${REDPANDA_WAIT_SLEEP_SECONDS:-2}"
+  local attempt=1
+
+  while (( attempt <= max_attempts )); do
+    if docker compose exec -T redpanda rpk cluster info >/dev/null 2>&1; then
+      return 0
+    fi
+
+    sleep "${sleep_seconds}"
+    attempt=$((attempt + 1))
+  done
+
+  echo "Redpanda did not become ready in time." >&2
+  exit 1
+}
+
+db_scalar() {
+  local query="$1"
+  docker compose exec -T \
+    -e MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" \
+    mysql mysql -uroot -Nse "${query}"
+}
+
+run_product_count() {
+  local phase_run_id="$1"
+  db_scalar "
+    SELECT COUNT(*)
+    FROM thock_product_db.products
+    WHERE name LIKE 'k6-${phase_run_id}-%';
+  "
+}
+
+run_outbox_total_count() {
+  local phase_run_id="$1"
+  db_scalar "
+    SELECT COUNT(*)
+    FROM thock_product_db.product_outbox_event e
+    JOIN thock_product_db.products p
+      ON CAST(e.event_key AS UNSIGNED) = p.id
+    WHERE p.name LIKE 'k6-${phase_run_id}-%';
+  "
+}
+
+run_outbox_status_count() {
+  local phase_run_id="$1"
+  local status="$2"
+  db_scalar "
+    SELECT COUNT(*)
+    FROM thock_product_db.product_outbox_event e
+    JOIN thock_product_db.products p
+      ON CAST(e.event_key AS UNSIGNED) = p.id
+    WHERE p.name LIKE 'k6-${phase_run_id}-%'
+      AND e.status = '${status}';
+  "
+}
+
+collect_topic_stats() {
+  local phase_run_id="$1"
+  local start_topic_count="$2"
+  bash loadtest/run-scoped-topic-stats.sh "${phase_run_id}" "${start_topic_count}" "${TOPIC}"
+}
+
+millis_now() {
+  echo $(( $(date +%s) * 1000 ))
+}
+
+start_product_service() {
+  local publish_mode="$1"
+  local poller_interval_ms="${2:-1000}"
+  local kafka_request_timeout_ms="${3:-1000}"
+  local kafka_delivery_timeout_ms="${4:-2000}"
+  local kafka_max_block_ms="${5:-1000}"
+  local direct_async_after_commit_enabled="${6:-false}"
+
+  PRODUCT_SERVICE_PROFILES_ACTIVE="${PRODUCT_SERVICE_PROFILES_ACTIVE}" \
+  PRODUCT_EVENT_PUBLISH_MODE="${publish_mode}" \
+  PRODUCT_OUTBOX_POLLER_INTERVAL_MS="${poller_interval_ms}" \
+  PRODUCT_KAFKA_REQUEST_TIMEOUT_MS="${kafka_request_timeout_ms}" \
+  PRODUCT_KAFKA_DELIVERY_TIMEOUT_MS="${kafka_delivery_timeout_ms}" \
+  PRODUCT_KAFKA_MAX_BLOCK_MS="${kafka_max_block_ms}" \
+  PRODUCT_EVENT_DIRECT_ASYNC_AFTER_COMMIT_ENABLED="${direct_async_after_commit_enabled}" \
+  PRODUCT_EVENT_DIRECT_ASYNC_CORE_POOL_SIZE="${DIRECT_ASYNC_CORE_POOL_SIZE}" \
+  PRODUCT_EVENT_DIRECT_ASYNC_MAX_POOL_SIZE="${DIRECT_ASYNC_MAX_POOL_SIZE}" \
+  PRODUCT_EVENT_DIRECT_ASYNC_QUEUE_CAPACITY="${DIRECT_ASYNC_QUEUE_CAPACITY}" \
+  docker compose up -d --build product-service
+}
+
+run_create_load() {
+  local phase_run_id="$1"
+  local summary_path="$2"
+  local enforce_create_success="${3:-true}"
+  local request_timeout="${4:-180s}"
+  local iterations_override="${5:-${K6_ITERATIONS}}"
+  local vus_override="${6:-${K6_VUS}}"
+
+  docker compose --profile loadtest run --no-deps --rm \
+    -e RUN_ID="${phase_run_id}" \
+    -e EXPERIMENT_NAME="product-outbox-before-after" \
+    -e SUMMARY_PATH="${summary_path}" \
+    -e BASE_URL="${BASE_URL}" \
+    -e PASSWORD="${K6_PASSWORD:-password123!}" \
+    -e K6_ITERATIONS="${iterations_override}" \
+    -e K6_VUS="${vus_override}" \
+    -e CATEGORY="${K6_CATEGORY:-KEYBOARD}" \
+    -e PRICE="${K6_PRICE:-1000}" \
+    -e SALE_PRICE="${K6_SALE_PRICE:-0}" \
+    -e STOCK="${K6_STOCK}" \
+    -e BANK_CODE="${K6_BANK_CODE:-088}" \
+    -e ACCOUNT_NUMBER="${K6_ACCOUNT_NUMBER:-1234567890}" \
+    -e ACCOUNT_HOLDER="${K6_ACCOUNT_HOLDER:-k6-seller}" \
+    -e SLEEP_BETWEEN="${K6_SLEEP_BETWEEN}" \
+    -e SELLER_ACCESS_TOKEN="${SELLER_ACCESS_TOKEN}" \
+    -e ENFORCE_CREATE_SUCCESS="${enforce_create_success}" \
+    -e REQUEST_TIMEOUT="${request_timeout}" \
+    k6 run /scripts/product-outbox-recovery.js
+}
+
+prepare_seller_access_token() {
+  docker compose --profile loadtest run --no-deps --rm \
+    -e RUN_ID="${RUN_ID}" \
+    -e BASE_URL="${BASE_URL}" \
+    -e PASSWORD="${K6_PASSWORD:-password123!}" \
+    -e BANK_CODE="${K6_BANK_CODE:-088}" \
+    -e ACCOUNT_NUMBER="${K6_ACCOUNT_NUMBER:-1234567890}" \
+    -e ACCOUNT_HOLDER="${K6_ACCOUNT_HOLDER:-k6-seller}" \
+    k6 run --quiet /scripts/prepare-seller-token.js 2>&1 \
+    | sed -n 's/.*__SELLER_ACCESS_TOKEN__=\([^ ]*\).*/\1/p' \
+    | tail -n 1
+}
+
+docker compose up -d mysql redpanda member-service api-gateway
+wait_for_redpanda
+wait_for_http "${GATEWAY_HEALTH_URL}"
+
+SELLER_ACCESS_TOKEN="$(prepare_seller_access_token)"
+if [[ -z "${SELLER_ACCESS_TOKEN}" ]]; then
+  echo "Failed to prepare seller access token." >&2
+  exit 1
+fi
+
+#
+# BEFORE: direct publish mode under broker outage, then product-service restart
+#
+start_product_service direct "${PRODUCT_OUTBOX_POLLER_INTERVAL_MS}" \
+  "${DIRECT_PRODUCT_KAFKA_REQUEST_TIMEOUT_MS}" \
+  "${DIRECT_PRODUCT_KAFKA_DELIVERY_TIMEOUT_MS}" \
+  "${DIRECT_PRODUCT_KAFKA_MAX_BLOCK_MS}" \
+  "${DIRECT_ASYNC_AFTER_COMMIT_ENABLED}"
+wait_for_http "${PRODUCT_SERVICE_HEALTH_URL}"
+sleep "${PHASE_START_GRACE_SECONDS}"
+
+if [[ "${DIRECT_WARMUP_ENABLED}" == "true" ]]; then
+  run_create_load "${DIRECT_WARMUP_RUN_ID}" \
+    "/results/product-outbox-before-${RUN_ID}-warmup-k6.json" \
+    true \
+    "${DIRECT_WARMUP_REQUEST_TIMEOUT:-30s}" \
+    "${DIRECT_WARMUP_ITERATIONS}" \
+    "${DIRECT_WARMUP_VUS}"
+  sleep "${DIRECT_WARMUP_SETTLE_SECONDS:-1}"
+fi
+
+BEFORE_START_TOPIC_COUNT="$(bash loadtest/topic-message-count.sh "${TOPIC}")"
+
+docker compose stop redpanda >/dev/null
+run_create_load "${BEFORE_PHASE_RUN_ID}" "${BEFORE_K6_SUMMARY_PATH}" false "${DIRECT_REQUEST_TIMEOUT:-5s}"
+
+BEFORE_DB_PRODUCTS_CREATED="$(run_product_count "${BEFORE_PHASE_RUN_ID}")"
+
+docker compose restart product-service >/dev/null
+sleep "${DIRECT_SETTLE_SECONDS}"
+
+docker compose up -d redpanda >/dev/null
+wait_for_redpanda
+wait_for_http "${PRODUCT_SERVICE_HEALTH_URL}"
+
+sleep "${DIRECT_SETTLE_SECONDS}"
+
+BEFORE_MATCHED_TOPIC_MESSAGES=0
+BEFORE_MATCHED_UNIQUE_PRODUCTS=0
+BEFORE_DUPLICATE_TOPIC_MESSAGES=0
+BEFORE_UNRELATED_TOPIC_MESSAGES=0
+
+while IFS='=' read -r key value; do
+  case "${key}" in
+    matched_topic_messages)
+      BEFORE_MATCHED_TOPIC_MESSAGES="${value}"
+      ;;
+    matched_unique_products)
+      BEFORE_MATCHED_UNIQUE_PRODUCTS="${value}"
+      ;;
+    duplicate_topic_messages)
+      BEFORE_DUPLICATE_TOPIC_MESSAGES="${value}"
+      ;;
+    unrelated_topic_messages)
+      BEFORE_UNRELATED_TOPIC_MESSAGES="${value}"
+      ;;
+  esac
+done < <(collect_topic_stats "${BEFORE_PHASE_RUN_ID}" "${BEFORE_START_TOPIC_COUNT}")
+
+BEFORE_MISSING_PUBLISHED_EVENT="$((BEFORE_DB_PRODUCTS_CREATED - BEFORE_MATCHED_UNIQUE_PRODUCTS))"
+
+#
+# AFTER: outbox mode under broker outage, then recovery convergence
+#
+start_product_service outbox "${PRODUCT_OUTBOX_POLLER_INTERVAL_MS}" \
+  "${AFTER_PRODUCT_KAFKA_REQUEST_TIMEOUT_MS}" \
+  "${AFTER_PRODUCT_KAFKA_DELIVERY_TIMEOUT_MS}" \
+  "${AFTER_PRODUCT_KAFKA_MAX_BLOCK_MS}" \
+  "false"
+wait_for_http "${PRODUCT_SERVICE_HEALTH_URL}"
+sleep "${PHASE_START_GRACE_SECONDS}"
+
+AFTER_START_TOPIC_COUNT="$(bash loadtest/topic-message-count.sh "${TOPIC}")"
+
+docker compose stop redpanda >/dev/null
+run_create_load "${AFTER_PHASE_RUN_ID}" "${AFTER_K6_SUMMARY_PATH}" true "${AFTER_REQUEST_TIMEOUT:-30s}"
+
+AFTER_DB_PRODUCTS_CREATED="$(run_product_count "${AFTER_PHASE_RUN_ID}")"
+AFTER_OUTBOX_TOTAL_BEFORE="$(run_outbox_total_count "${AFTER_PHASE_RUN_ID}")"
+AFTER_OUTBOX_PENDING_BEFORE="$(run_outbox_status_count "${AFTER_PHASE_RUN_ID}" PENDING)"
+AFTER_OUTBOX_SENT_BEFORE="$(run_outbox_status_count "${AFTER_PHASE_RUN_ID}" SENT)"
+AFTER_OUTBOX_FAILED_BEFORE="$(run_outbox_status_count "${AFTER_PHASE_RUN_ID}" FAILED)"
+
+docker compose up -d redpanda >/dev/null
+wait_for_redpanda
+
+RECOVERY_STARTED_AT_MILLIS="$(millis_now)"
+
+docker compose restart product-service >/dev/null
+wait_for_http "${PRODUCT_SERVICE_HEALTH_URL}"
+
+RECOVERY_POLL_ATTEMPTS=0
+AFTER_MATCHED_TOPIC_MESSAGES=0
+AFTER_MATCHED_UNIQUE_PRODUCTS=0
+AFTER_DUPLICATE_TOPIC_MESSAGES=0
+AFTER_UNRELATED_TOPIC_MESSAGES=0
+AFTER_OUTBOX_TOTAL_AFTER=0
+AFTER_OUTBOX_PENDING_AFTER=0
+AFTER_OUTBOX_SENT_AFTER=0
+AFTER_OUTBOX_FAILED_AFTER=0
+
+while true; do
+  RECOVERY_POLL_ATTEMPTS=$((RECOVERY_POLL_ATTEMPTS + 1))
+
+  AFTER_OUTBOX_TOTAL_AFTER="$(run_outbox_total_count "${AFTER_PHASE_RUN_ID}")"
+  AFTER_OUTBOX_PENDING_AFTER="$(run_outbox_status_count "${AFTER_PHASE_RUN_ID}" PENDING)"
+  AFTER_OUTBOX_SENT_AFTER="$(run_outbox_status_count "${AFTER_PHASE_RUN_ID}" SENT)"
+  AFTER_OUTBOX_FAILED_AFTER="$(run_outbox_status_count "${AFTER_PHASE_RUN_ID}" FAILED)"
+
+  while IFS='=' read -r key value; do
+    case "${key}" in
+      matched_topic_messages)
+        AFTER_MATCHED_TOPIC_MESSAGES="${value}"
+        ;;
+      matched_unique_products)
+        AFTER_MATCHED_UNIQUE_PRODUCTS="${value}"
+        ;;
+      duplicate_topic_messages)
+        AFTER_DUPLICATE_TOPIC_MESSAGES="${value}"
+        ;;
+      unrelated_topic_messages)
+        AFTER_UNRELATED_TOPIC_MESSAGES="${value}"
+        ;;
+    esac
+  done < <(collect_topic_stats "${AFTER_PHASE_RUN_ID}" "${AFTER_START_TOPIC_COUNT}")
+
+  if [[ "${AFTER_OUTBOX_PENDING_AFTER}" == "0" ]] \
+    && [[ "${AFTER_OUTBOX_FAILED_AFTER}" == "0" ]] \
+    && [[ "${AFTER_OUTBOX_SENT_AFTER}" == "${AFTER_DB_PRODUCTS_CREATED}" ]] \
+    && [[ "${AFTER_MATCHED_UNIQUE_PRODUCTS}" == "${AFTER_DB_PRODUCTS_CREATED}" ]]; then
+    break
+  fi
+
+  if (( RECOVERY_POLL_ATTEMPTS * RECOVERY_POLL_INTERVAL_SECONDS >= RECOVERY_POLL_TIMEOUT_SECONDS )); then
+    echo "Outbox recovery did not converge in time." >&2
+    exit 1
+  fi
+
+  sleep "${RECOVERY_POLL_INTERVAL_SECONDS}"
+done
+
+RECOVERY_COMPLETED_AT_MILLIS="$(millis_now)"
+RECOVERY_DURATION_MILLIS="$((RECOVERY_COMPLETED_AT_MILLIS - RECOVERY_STARTED_AT_MILLIS))"
+AFTER_MISSING_PUBLISHED_EVENT="$((AFTER_DB_PRODUCTS_CREATED - AFTER_MATCHED_UNIQUE_PRODUCTS))"
+
+jq -n \
+  --arg runId "${RUN_ID}" \
+  --arg topic "${TOPIC}" \
+  --arg beforePhaseRunId "${BEFORE_PHASE_RUN_ID}" \
+  --arg afterPhaseRunId "${AFTER_PHASE_RUN_ID}" \
+  --arg profiles "${PRODUCT_SERVICE_PROFILES_ACTIVE}" \
+  --arg directAsyncAfterCommitEnabled "${DIRECT_ASYNC_AFTER_COMMIT_ENABLED}" \
+  --arg directWarmupEnabled "${DIRECT_WARMUP_ENABLED}" \
+  --argjson iterations "${K6_ITERATIONS}" \
+  --argjson vus "${K6_VUS}" \
+  --argjson stock "${K6_STOCK}" \
+  --argjson directKafkaRequestTimeoutMs "${DIRECT_PRODUCT_KAFKA_REQUEST_TIMEOUT_MS}" \
+  --argjson directKafkaDeliveryTimeoutMs "${DIRECT_PRODUCT_KAFKA_DELIVERY_TIMEOUT_MS}" \
+  --argjson directKafkaMaxBlockMs "${DIRECT_PRODUCT_KAFKA_MAX_BLOCK_MS}" \
+  --argjson beforeStartTopicCount "${BEFORE_START_TOPIC_COUNT}" \
+  --argjson beforeDbProductsCreated "${BEFORE_DB_PRODUCTS_CREATED}" \
+  --argjson beforeMatchedTopicMessages "${BEFORE_MATCHED_TOPIC_MESSAGES}" \
+  --argjson beforeMatchedUniqueProducts "${BEFORE_MATCHED_UNIQUE_PRODUCTS}" \
+  --argjson beforeDuplicateTopicMessages "${BEFORE_DUPLICATE_TOPIC_MESSAGES}" \
+  --argjson beforeUnrelatedTopicMessages "${BEFORE_UNRELATED_TOPIC_MESSAGES}" \
+  --argjson beforeMissingPublishedEvent "${BEFORE_MISSING_PUBLISHED_EVENT}" \
+  --argjson afterStartTopicCount "${AFTER_START_TOPIC_COUNT}" \
+  --argjson afterDbProductsCreated "${AFTER_DB_PRODUCTS_CREATED}" \
+  --argjson afterOutboxTotalBefore "${AFTER_OUTBOX_TOTAL_BEFORE}" \
+  --argjson afterOutboxPendingBefore "${AFTER_OUTBOX_PENDING_BEFORE}" \
+  --argjson afterOutboxSentBefore "${AFTER_OUTBOX_SENT_BEFORE}" \
+  --argjson afterOutboxFailedBefore "${AFTER_OUTBOX_FAILED_BEFORE}" \
+  --argjson afterOutboxTotalAfter "${AFTER_OUTBOX_TOTAL_AFTER}" \
+  --argjson afterOutboxPendingAfter "${AFTER_OUTBOX_PENDING_AFTER}" \
+  --argjson afterOutboxSentAfter "${AFTER_OUTBOX_SENT_AFTER}" \
+  --argjson afterOutboxFailedAfter "${AFTER_OUTBOX_FAILED_AFTER}" \
+  --argjson afterMatchedTopicMessages "${AFTER_MATCHED_TOPIC_MESSAGES}" \
+  --argjson afterMatchedUniqueProducts "${AFTER_MATCHED_UNIQUE_PRODUCTS}" \
+  --argjson afterDuplicateTopicMessages "${AFTER_DUPLICATE_TOPIC_MESSAGES}" \
+  --argjson afterUnrelatedTopicMessages "${AFTER_UNRELATED_TOPIC_MESSAGES}" \
+  --argjson afterMissingPublishedEvent "${AFTER_MISSING_PUBLISHED_EVENT}" \
+  --argjson recoveryStartedAtMillis "${RECOVERY_STARTED_AT_MILLIS}" \
+  --argjson recoveryCompletedAtMillis "${RECOVERY_COMPLETED_AT_MILLIS}" \
+  --argjson recoveryDurationMillis "${RECOVERY_DURATION_MILLIS}" \
+  --argjson recoveryPollAttempts "${RECOVERY_POLL_ATTEMPTS}" \
+  --arg beforeK6SummaryPath "${BEFORE_K6_SUMMARY_PATH}" \
+  --arg afterK6SummaryPath "${AFTER_K6_SUMMARY_PATH}" \
+  '
+  {
+    runId: $runId,
+    config: {
+      topic: $topic,
+      productServiceProfilesActive: $profiles,
+      iterations: $iterations,
+      vus: $vus,
+      stock: $stock,
+      beforeMode: "direct",
+      afterMode: "outbox",
+      beforeDirectAsyncAfterCommitEnabled: $directAsyncAfterCommitEnabled,
+      beforeDirectWarmupEnabled: $directWarmupEnabled,
+      beforeDirectKafkaRequestTimeoutMs: $directKafkaRequestTimeoutMs,
+      beforeDirectKafkaDeliveryTimeoutMs: $directKafkaDeliveryTimeoutMs,
+      beforeDirectKafkaMaxBlockMs: $directKafkaMaxBlockMs,
+      brokerDownDuringCreate: true,
+      productServiceRestartBeforeBrokerRecovery: true,
+      productServiceRestartDuringRecovery: true
+    },
+    paths: {
+      beforeK6SummaryPath: $beforeK6SummaryPath,
+      afterK6SummaryPath: $afterK6SummaryPath
+    },
+    before: {
+      phaseRunId: $beforePhaseRunId,
+      startTopicCount: $beforeStartTopicCount,
+      dbProductsCreated: $beforeDbProductsCreated,
+      matchedTopicMessages: $beforeMatchedTopicMessages,
+      matchedUniqueProducts: $beforeMatchedUniqueProducts,
+      duplicateTopicMessages: $beforeDuplicateTopicMessages,
+      unrelatedTopicMessages: $beforeUnrelatedTopicMessages,
+      missingPublishedEvent: $beforeMissingPublishedEvent
+    },
+    after: {
+      phaseRunId: $afterPhaseRunId,
+      startTopicCount: $afterStartTopicCount,
+      dbProductsCreated: $afterDbProductsCreated,
+      beforeRecovery: {
+        outboxTotalCount: $afterOutboxTotalBefore,
+        pendingCount: $afterOutboxPendingBefore,
+        sentCount: $afterOutboxSentBefore,
+        failedCount: $afterOutboxFailedBefore
+      },
+      afterRecovery: {
+        outboxTotalCount: $afterOutboxTotalAfter,
+        pendingCount: $afterOutboxPendingAfter,
+        sentCount: $afterOutboxSentAfter,
+        failedCount: $afterOutboxFailedAfter,
+        matchedTopicMessages: $afterMatchedTopicMessages,
+        matchedUniqueProducts: $afterMatchedUniqueProducts,
+        duplicateTopicMessages: $afterDuplicateTopicMessages,
+        unrelatedTopicMessages: $afterUnrelatedTopicMessages,
+        missingPublishedEvent: $afterMissingPublishedEvent
+      },
+      recovery: {
+        startedAtMillis: $recoveryStartedAtMillis,
+        completedAtMillis: $recoveryCompletedAtMillis,
+        durationMillis: $recoveryDurationMillis,
+        pollAttempts: $recoveryPollAttempts
+      }
+    },
+    validations: {
+      beforeLostEventsDetected: ($beforeDbProductsCreated > 0 and $beforeMissingPublishedEvent > 0),
+      beforeNoDuplicateTopicMessage: ($beforeDuplicateTopicMessages == 0),
+      afterPendingAccumulatedBeforeRecovery: ($afterOutboxPendingBefore == $afterDbProductsCreated and $afterDbProductsCreated > 0),
+      afterAllOutboxSentAfterRecovery: ($afterOutboxPendingAfter == 0 and $afterOutboxFailedAfter == 0 and $afterOutboxSentAfter == $afterDbProductsCreated),
+      afterNoEventLoss: ($afterMissingPublishedEvent == 0),
+      afterNoDuplicateTopicMessage: ($afterDuplicateTopicMessages == 0)
+    }
+  }
+  ' > "${RESULT_PATH}"
+
+cat <<EOF
+run_id=${RUN_ID}
+result_path=${RESULT_PATH}
+before_db_products_created=${BEFORE_DB_PRODUCTS_CREATED}
+before_missing_published_event=${BEFORE_MISSING_PUBLISHED_EVENT}
+after_db_products_created=${AFTER_DB_PRODUCTS_CREATED}
+after_outbox_pending_before=${AFTER_OUTBOX_PENDING_BEFORE}
+after_outbox_sent_after=${AFTER_OUTBOX_SENT_AFTER}
+after_missing_published_event=${AFTER_MISSING_PUBLISHED_EVENT}
+recovery_duration_ms=${RECOVERY_DURATION_MILLIS}
+EOF

--- a/loadtest/run-product-outbox-recovery-experiment.sh
+++ b/loadtest/run-product-outbox-recovery-experiment.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd jq
+
+RUN_ID="${RUN_ID:-$(date +%s)}"
+TOPIC="${TOPIC:-product.changed}"
+MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-root}"
+BASE_URL="${K6_BASE_URL:-http://api-gateway:8080}"
+PRODUCT_SERVICE_BASE_URL="${PRODUCT_SERVICE_BASE_URL:-http://product-service:8082}"
+PRODUCT_SERVICE_HEALTH_URL="${PRODUCT_SERVICE_HEALTH_URL:-${PRODUCT_SERVICE_BASE_URL}/actuator/health}"
+GATEWAY_HEALTH_URL="${GATEWAY_HEALTH_URL:-http://api-gateway:8080/actuator/health}"
+
+PRODUCT_SERVICE_PROFILES_ACTIVE="${PRODUCT_SERVICE_PROFILES_ACTIVE:-docker,experiment}"
+PRODUCT_EVENT_PUBLISH_MODE="${PRODUCT_EVENT_PUBLISH_MODE:-outbox}"
+PRODUCT_OUTBOX_POLLER_INTERVAL_MS="${PRODUCT_OUTBOX_POLLER_INTERVAL_MS:-1000}"
+
+K6_ITERATIONS="${K6_ITERATIONS:-2400}"
+K6_VUS="${K6_VUS:-50}"
+K6_STOCK="${K6_STOCK:-5}"
+K6_SLEEP_BETWEEN="${K6_SLEEP_BETWEEN:-0}"
+K6_SUMMARY_PATH="/results/product-outbox-recovery-${RUN_ID}-k6.json"
+
+RECOVERY_POLL_INTERVAL_SECONDS="${RECOVERY_POLL_INTERVAL_SECONDS:-1}"
+RECOVERY_POLL_TIMEOUT_SECONDS="${RECOVERY_POLL_TIMEOUT_SECONDS:-300}"
+
+RESULT_PATH="loadtest/results/product-outbox-recovery-${RUN_ID}.json"
+
+wait_for_http() {
+  local url="$1"
+  docker compose --profile loadtest run --no-deps --rm \
+    -e WAIT_URL="${url}" \
+    -e WAIT_MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS:-60}" \
+    -e WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS:-2}" \
+    -e WAIT_STABLE_SUCCESSES="${WAIT_STABLE_SUCCESSES:-3}" \
+    k6 run /scripts/wait-http.js >/dev/null
+}
+
+wait_for_redpanda() {
+  local max_attempts="${REDPANDA_WAIT_MAX_ATTEMPTS:-60}"
+  local sleep_seconds="${REDPANDA_WAIT_SLEEP_SECONDS:-2}"
+  local attempt=1
+
+  while (( attempt <= max_attempts )); do
+    if docker compose exec -T redpanda rpk cluster info >/dev/null 2>&1; then
+      return 0
+    fi
+
+    sleep "${sleep_seconds}"
+    attempt=$((attempt + 1))
+  done
+
+  echo "Redpanda did not become ready in time." >&2
+  exit 1
+}
+
+db_scalar() {
+  local query="$1"
+  docker compose exec -T \
+    -e MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" \
+    mysql mysql -uroot -Nse "${query}"
+}
+
+run_product_count() {
+  db_scalar "
+    SELECT COUNT(*)
+    FROM thock_product_db.products
+    WHERE name LIKE 'k6-${RUN_ID}-%';
+  "
+}
+
+run_outbox_total_count() {
+  db_scalar "
+    SELECT COUNT(*)
+    FROM thock_product_db.product_outbox_event e
+    JOIN thock_product_db.products p
+      ON CAST(e.event_key AS UNSIGNED) = p.id
+    WHERE p.name LIKE 'k6-${RUN_ID}-%';
+  "
+}
+
+run_outbox_status_count() {
+  local status="$1"
+  db_scalar "
+    SELECT COUNT(*)
+    FROM thock_product_db.product_outbox_event e
+    JOIN thock_product_db.products p
+      ON CAST(e.event_key AS UNSIGNED) = p.id
+    WHERE p.name LIKE 'k6-${RUN_ID}-%'
+      AND e.status = '${status}';
+  "
+}
+
+collect_topic_stats() {
+  bash loadtest/run-scoped-topic-stats.sh "${RUN_ID}" "${START_TOPIC_COUNT}" "${TOPIC}"
+}
+
+millis_now() {
+  echo $(( $(date +%s) * 1000 ))
+}
+
+docker compose up -d mysql redpanda member-service api-gateway
+
+PRODUCT_SERVICE_PROFILES_ACTIVE="${PRODUCT_SERVICE_PROFILES_ACTIVE}" \
+PRODUCT_EVENT_PUBLISH_MODE="${PRODUCT_EVENT_PUBLISH_MODE}" \
+PRODUCT_OUTBOX_POLLER_INTERVAL_MS="${PRODUCT_OUTBOX_POLLER_INTERVAL_MS}" \
+docker compose up -d --build product-service
+
+wait_for_redpanda
+wait_for_http "${GATEWAY_HEALTH_URL}"
+wait_for_http "${PRODUCT_SERVICE_HEALTH_URL}"
+
+START_TOPIC_COUNT="$(bash loadtest/topic-message-count.sh "${TOPIC}")"
+
+docker compose stop redpanda >/dev/null
+
+docker compose --profile loadtest run --no-deps --rm \
+  -e RUN_ID="${RUN_ID}" \
+  -e EXPERIMENT_NAME="product-outbox-recovery" \
+  -e SUMMARY_PATH="${K6_SUMMARY_PATH}" \
+  -e BASE_URL="${BASE_URL}" \
+  -e PASSWORD="${K6_PASSWORD:-password123!}" \
+  -e K6_ITERATIONS="${K6_ITERATIONS}" \
+  -e K6_VUS="${K6_VUS}" \
+  -e CATEGORY="${K6_CATEGORY:-KEYBOARD}" \
+  -e PRICE="${K6_PRICE:-1000}" \
+  -e SALE_PRICE="${K6_SALE_PRICE:-0}" \
+  -e STOCK="${K6_STOCK}" \
+  -e BANK_CODE="${K6_BANK_CODE:-088}" \
+  -e ACCOUNT_NUMBER="${K6_ACCOUNT_NUMBER:-1234567890}" \
+  -e ACCOUNT_HOLDER="${K6_ACCOUNT_HOLDER:-k6-seller}" \
+  -e SLEEP_BETWEEN="${K6_SLEEP_BETWEEN}" \
+  k6 run /scripts/product-outbox-recovery.js
+
+DB_PRODUCTS_CREATED="$(run_product_count)"
+OUTBOX_TOTAL_BEFORE="$(run_outbox_total_count)"
+OUTBOX_PENDING_BEFORE="$(run_outbox_status_count PENDING)"
+OUTBOX_SENT_BEFORE="$(run_outbox_status_count SENT)"
+OUTBOX_FAILED_BEFORE="$(run_outbox_status_count FAILED)"
+
+docker compose up -d redpanda >/dev/null
+wait_for_redpanda
+
+RECOVERY_STARTED_AT_MILLIS="$(millis_now)"
+
+docker compose restart product-service >/dev/null
+wait_for_http "${PRODUCT_SERVICE_HEALTH_URL}"
+
+RECOVERY_POLL_ATTEMPTS=0
+MATCHED_TOPIC_MESSAGES=0
+MATCHED_UNIQUE_PRODUCTS=0
+DUPLICATE_TOPIC_MESSAGES=0
+UNRELATED_TOPIC_MESSAGES=0
+OUTBOX_TOTAL_AFTER=0
+OUTBOX_PENDING_AFTER=0
+OUTBOX_SENT_AFTER=0
+OUTBOX_FAILED_AFTER=0
+
+while true; do
+  RECOVERY_POLL_ATTEMPTS=$((RECOVERY_POLL_ATTEMPTS + 1))
+
+  OUTBOX_TOTAL_AFTER="$(run_outbox_total_count)"
+  OUTBOX_PENDING_AFTER="$(run_outbox_status_count PENDING)"
+  OUTBOX_SENT_AFTER="$(run_outbox_status_count SENT)"
+  OUTBOX_FAILED_AFTER="$(run_outbox_status_count FAILED)"
+
+  while IFS='=' read -r key value; do
+    case "${key}" in
+      matched_topic_messages)
+        MATCHED_TOPIC_MESSAGES="${value}"
+        ;;
+      matched_unique_products)
+        MATCHED_UNIQUE_PRODUCTS="${value}"
+        ;;
+      duplicate_topic_messages)
+        DUPLICATE_TOPIC_MESSAGES="${value}"
+        ;;
+      unrelated_topic_messages)
+        UNRELATED_TOPIC_MESSAGES="${value}"
+        ;;
+    esac
+  done < <(collect_topic_stats)
+
+  if [[ "${OUTBOX_PENDING_AFTER}" == "0" ]] \
+    && [[ "${OUTBOX_FAILED_AFTER}" == "0" ]] \
+    && [[ "${OUTBOX_SENT_AFTER}" == "${DB_PRODUCTS_CREATED}" ]] \
+    && [[ "${MATCHED_UNIQUE_PRODUCTS}" == "${DB_PRODUCTS_CREATED}" ]]; then
+    break
+  fi
+
+  if (( RECOVERY_POLL_ATTEMPTS * RECOVERY_POLL_INTERVAL_SECONDS >= RECOVERY_POLL_TIMEOUT_SECONDS )); then
+    echo "Outbox recovery did not converge in time." >&2
+    exit 1
+  fi
+
+  sleep "${RECOVERY_POLL_INTERVAL_SECONDS}"
+done
+
+RECOVERY_COMPLETED_AT_MILLIS="$(millis_now)"
+RECOVERY_DURATION_MILLIS="$((RECOVERY_COMPLETED_AT_MILLIS - RECOVERY_STARTED_AT_MILLIS))"
+MISSING_PUBLISHED_EVENT="$((DB_PRODUCTS_CREATED - MATCHED_UNIQUE_PRODUCTS))"
+
+jq -n \
+  --arg runId "${RUN_ID}" \
+  --arg topic "${TOPIC}" \
+  --argjson startTopicCount "${START_TOPIC_COUNT}" \
+  --arg profiles "${PRODUCT_SERVICE_PROFILES_ACTIVE}" \
+  --arg publishMode "${PRODUCT_EVENT_PUBLISH_MODE}" \
+  --argjson pollerIntervalMs "${PRODUCT_OUTBOX_POLLER_INTERVAL_MS}" \
+  --argjson iterations "${K6_ITERATIONS}" \
+  --argjson vus "${K6_VUS}" \
+  --argjson stock "${K6_STOCK}" \
+  --arg k6SummaryPath "${K6_SUMMARY_PATH}" \
+  --argjson dbProductsCreated "${DB_PRODUCTS_CREATED}" \
+  --argjson outboxTotalBefore "${OUTBOX_TOTAL_BEFORE}" \
+  --argjson outboxPendingBefore "${OUTBOX_PENDING_BEFORE}" \
+  --argjson outboxSentBefore "${OUTBOX_SENT_BEFORE}" \
+  --argjson outboxFailedBefore "${OUTBOX_FAILED_BEFORE}" \
+  --argjson outboxTotalAfter "${OUTBOX_TOTAL_AFTER}" \
+  --argjson outboxPendingAfter "${OUTBOX_PENDING_AFTER}" \
+  --argjson outboxSentAfter "${OUTBOX_SENT_AFTER}" \
+  --argjson outboxFailedAfter "${OUTBOX_FAILED_AFTER}" \
+  --argjson matchedTopicMessages "${MATCHED_TOPIC_MESSAGES}" \
+  --argjson matchedUniqueProducts "${MATCHED_UNIQUE_PRODUCTS}" \
+  --argjson duplicateTopicMessages "${DUPLICATE_TOPIC_MESSAGES}" \
+  --argjson unrelatedTopicMessages "${UNRELATED_TOPIC_MESSAGES}" \
+  --argjson missingPublishedEvent "${MISSING_PUBLISHED_EVENT}" \
+  --argjson recoveryStartedAtMillis "${RECOVERY_STARTED_AT_MILLIS}" \
+  --argjson recoveryCompletedAtMillis "${RECOVERY_COMPLETED_AT_MILLIS}" \
+  --argjson recoveryDurationMillis "${RECOVERY_DURATION_MILLIS}" \
+  --argjson recoveryPollAttempts "${RECOVERY_POLL_ATTEMPTS}" \
+  '
+  {
+    runId: $runId,
+    config: {
+      topic: $topic,
+      productServiceProfilesActive: $profiles,
+      productEventPublishMode: $publishMode,
+      productOutboxPollerIntervalMs: $pollerIntervalMs,
+      iterations: $iterations,
+      vus: $vus,
+      stock: $stock,
+      brokerDownDuringCreate: true,
+      productServiceRestartDuringRecovery: true
+    },
+    paths: {
+      k6SummaryPath: $k6SummaryPath
+    },
+    beforeRecovery: {
+      dbProductsCreated: $dbProductsCreated,
+      outboxTotalCount: $outboxTotalBefore,
+      pendingCount: $outboxPendingBefore,
+      sentCount: $outboxSentBefore,
+      failedCount: $outboxFailedBefore,
+      startTopicCount: $startTopicCount
+    },
+    afterRecovery: {
+      outboxTotalCount: $outboxTotalAfter,
+      pendingCount: $outboxPendingAfter,
+      sentCount: $outboxSentAfter,
+      failedCount: $outboxFailedAfter,
+      matchedTopicMessages: $matchedTopicMessages,
+      matchedUniqueProducts: $matchedUniqueProducts,
+      duplicateTopicMessages: $duplicateTopicMessages,
+      unrelatedTopicMessages: $unrelatedTopicMessages,
+      missingPublishedEvent: $missingPublishedEvent
+    },
+    recovery: {
+      startedAtMillis: $recoveryStartedAtMillis,
+      completedAtMillis: $recoveryCompletedAtMillis,
+      durationMillis: $recoveryDurationMillis,
+      pollAttempts: $recoveryPollAttempts
+    },
+    validations: {
+      allCreatesPersisted: ($dbProductsCreated == $iterations),
+      pendingAccumulatedBeforeRecovery: ($outboxPendingBefore == $dbProductsCreated and $dbProductsCreated > 0),
+      allOutboxSentAfterRecovery: ($outboxPendingAfter == 0 and $outboxFailedAfter == 0 and $outboxSentAfter == $dbProductsCreated),
+      noEventLoss: ($missingPublishedEvent == 0),
+      noDuplicateTopicMessage: ($duplicateTopicMessages == 0)
+    }
+  }
+  ' > "${RESULT_PATH}"
+
+cat <<EOF
+run_id=${RUN_ID}
+result_path=${RESULT_PATH}
+db_products_created=${DB_PRODUCTS_CREATED}
+outbox_pending_before=${OUTBOX_PENDING_BEFORE}
+outbox_sent_after=${OUTBOX_SENT_AFTER}
+matched_unique_products=${MATCHED_UNIQUE_PRODUCTS}
+missing_published_event=${MISSING_PUBLISHED_EVENT}
+recovery_duration_ms=${RECOVERY_DURATION_MILLIS}
+EOF

--- a/loadtest/run-scoped-topic-stats.sh
+++ b/loadtest/run-scoped-topic-stats.sh
@@ -31,7 +31,9 @@ cleanup() {
 
 trap cleanup EXIT
 
-docker compose exec -T mysql mysql -uroot "-p${MYSQL_ROOT_PASSWORD}" -Nse \
+docker compose exec -T \
+  -e MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" \
+  mysql mysql -uroot -Nse \
   "SELECT id
    FROM thock_product_db.products
    WHERE name LIKE 'k6-${RUN_ID}-%'

--- a/product-service/src/main/java/com/thock/back/product/config/ProductDirectPublishAsyncConfig.java
+++ b/product-service/src/main/java/com/thock/back/product/config/ProductDirectPublishAsyncConfig.java
@@ -1,0 +1,27 @@
+package com.thock.back.product.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class ProductDirectPublishAsyncConfig {
+
+    @Bean("productDirectPublishExecutor")
+    public TaskExecutor productDirectPublishExecutor(
+            @Value("${product.event.direct.async.core-pool-size:8}") int corePoolSize,
+            @Value("${product.event.direct.async.max-pool-size:16}") int maxPoolSize,
+            @Value("${product.event.direct.async.queue-capacity:2000}") int queueCapacity
+    ) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadNamePrefix("product-direct-publish-");
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setWaitForTasksToCompleteOnShutdown(false);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/product-service/src/main/java/com/thock/back/product/config/kafka/ProductKafkaConfig.java
+++ b/product-service/src/main/java/com/thock/back/product/config/kafka/ProductKafkaConfig.java
@@ -25,6 +25,15 @@ public class ProductKafkaConfig {
     @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
     private String bootstrapServers;
 
+    @Value("${product.kafka.request-timeout-ms:30000}")
+    private int requestTimeoutMs;
+
+    @Value("${product.kafka.delivery-timeout-ms:120000}")
+    private int deliveryTimeoutMs;
+
+    @Value("${product.kafka.max-block-ms:60000}")
+    private int maxBlockMs;
+
     private ObjectMapper kafkaObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
@@ -40,8 +49,9 @@ public class ProductKafkaConfig {
         configProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
         configProps.put(ProducerConfig.ACKS_CONFIG, "all");
         configProps.put(ProducerConfig.RETRIES_CONFIG, Integer.MAX_VALUE);
-        configProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 120_000);
-        configProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30_000);
+        configProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, deliveryTimeoutMs);
+        configProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
+        configProps.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, maxBlockMs);
 
         JsonSerializer<Object> jsonSerializer = new JsonSerializer<>(kafkaObjectMapper());
         jsonSerializer.setAddTypeInfo(true);

--- a/product-service/src/main/java/com/thock/back/product/messaging/publisher/ProductDirectKafkaEventPublisher.java
+++ b/product-service/src/main/java/com/thock/back/product/messaging/publisher/ProductDirectKafkaEventPublisher.java
@@ -5,8 +5,10 @@ import com.thock.back.shared.product.event.ProductEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,10 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public class ProductDirectKafkaEventPublisher implements ProductEventPublisher {
 
     private final @Qualifier("productKafkaTemplate") KafkaTemplate<String, Object> productKafkaTemplate;
+    private final @Qualifier("productDirectPublishExecutor") TaskExecutor productDirectPublishExecutor;
+
+    @Value("${product.event.direct.async-after-commit-enabled:false}")
+    private boolean asyncAfterCommitEnabled;
 
     @Override
     @Transactional(propagation = Propagation.MANDATORY)
@@ -28,13 +34,32 @@ public class ProductDirectKafkaEventPublisher implements ProductEventPublisher {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    send(event);
+                    dispatchAfterCommit(event);
                 }
             });
             return;
         }
 
-        send(event);
+        dispatchAfterCommit(event);
+    }
+
+    private void dispatchAfterCommit(ProductEvent event) {
+        if (asyncAfterCommitEnabled) {
+            productDirectPublishExecutor.execute(() -> sendSafely(event));
+            return;
+        }
+
+        sendSafely(event);
+    }
+
+    private void sendSafely(ProductEvent event) {
+        try {
+            send(event);
+        } catch (Exception e) {
+            String eventKey = String.valueOf(event.productId());
+            log.error("Failed to publish product event directly before send completion. key={}, error={}",
+                    eventKey, e.getMessage(), e);
+        }
     }
 
     private void send(ProductEvent event) {

--- a/product-service/src/main/resources/application-experiment.yml
+++ b/product-service/src/main/resources/application-experiment.yml
@@ -12,6 +12,12 @@ product:
     replicas: ${PRODUCT_PARTITION_EXPERIMENT_TOPIC_REPLICAS:1}
   event:
     publish-mode: ${PRODUCT_EVENT_PUBLISH_MODE:outbox}
+    direct:
+      async-after-commit-enabled: ${PRODUCT_EVENT_DIRECT_ASYNC_AFTER_COMMIT_ENABLED:false}
+      async:
+        core-pool-size: ${PRODUCT_EVENT_DIRECT_ASYNC_CORE_POOL_SIZE:8}
+        max-pool-size: ${PRODUCT_EVENT_DIRECT_ASYNC_MAX_POOL_SIZE:16}
+        queue-capacity: ${PRODUCT_EVENT_DIRECT_ASYNC_QUEUE_CAPACITY:2000}
   inbox:
     enabled: ${PRODUCT_INBOX_ENABLED:true}
     cleanup:


### PR DESCRIPTION
## 관련 이슈
Closes #61 

## 변경 내용
- `product-service`의 이벤트 발행 구조를 `direct` / `outbox`로 전환할 수 있는 실험 환경을 보강했습니다.
- broker 장애 상황에서 상품 생성 요청을 반복 수행하는 k6 시나리오와 Outbox recovery wrapper를 추가했습니다.
- `run-product-outbox-before-after-experiment.sh`를 추가해 `Direct Kafka` BEFORE와 `Outbox` AFTER를 한 번에 비교할 수 있도록 구성했습니다.
- run_id 기준으로 DB 상품 수, Kafka topic 반영 수, Outbox 상태를 집계해 `missingPublishedEvent`, `pendingCount`, `sentCount`, `duplicateTopicMessages`를 비교할 수 있도록 했습니다.
- direct baseline에 metadata warm-up, 짧은 producer timeout, afterCommit 비동기 offload를 적용해 실무적으로 시도할 수 있는 완화책 이후에도 유실이 남는지 확인할 수 있도록 했습니다.
- `docs/product-outbox-before-after-analysis.md`에 테스트 조건, 측정 기준, direct Kafka의 한계, Outbox 선택 이유를 정리했습니다.
- `loadtest/README.md`에 실행 방법과 핵심 결과 필드를 추가했습니다.

## 확인 내용
- `RUN_ID=1776235550 bash loadtest/run-product-outbox-before-after-experiment.sh` 실행 기준
- BEFORE `Direct Kafka`
  - `dbProductsCreated = 2400`
  - `matchedUniqueProducts = 0`
  - `missingPublishedEvent = 2400`
- AFTER `Outbox`
  - `dbProductsCreated = 2400`
  - `pendingCount = 2400 -> 0`
  - `sentCount = 0 -> 2400`
  - `matchedUniqueProducts = 2400`
  - `missingPublishedEvent = 0`
  - `duplicateTopicMessages = 50`
- direct는 no-loss를 보장하지 못하고, outbox는 복구 후 유실 0건으로 수렴함을 확인했습니다. 