### PR TITLE
[TEST] Product Inbox Before/After 중복 소비 차단 실험 환경 추가

### DIFF
--- a/docs/product-inbox-before-after-analysis.md
+++ b/docs/product-inbox-before-after-analysis.md
@@ -1,0 +1,252 @@
+# Product Inbox Before/After Experiment Analysis
+
+## 1. 실험 목적
+
+이 실험은 재고 변경 이벤트 소비 구조를 아래 두 방식으로 비교하기 위해 설계했다.
+
+- BEFORE: 중복 방지 없이 이벤트를 그대로 소비
+- AFTER: `Inbox` 기반 idempotency를 적용해 동일 이벤트를 한 번만 소비
+
+검증하고자 한 핵심은 두 가지다.
+
+- 동일 이벤트가 여러 번 들어오면 실제 재고 반영이 중복되는가
+- Inbox를 적용하면 중복 메시지가 실제로 차단되는가
+
+즉 이 실험은 단순 소비 성능 비교가 아니라, **Outbox의 at-least-once 발행 이후 남는 duplicate consume 문제를 Inbox가 실제로 해결하는지** 검증하는 correctness 실험이다.
+
+## 2. 왜 Inbox가 필요한가
+
+Outbox 실험에서 broker 장애 후 복구 시:
+
+- direct는 유실이 발생했고
+- outbox는 유실 0건으로 수렴했지만
+- duplicate publish가 남을 수 있음을 확인했다
+
+즉 Outbox는 **no-loss**를 해결하지만, **no-duplicate**를 해결하지는 않는다.
+
+따라서 소비 측에서는:
+
+- 같은 이벤트가 재전달되더라도
+- 비즈니스 로직이 한 번만 적용되도록
+
+중복 소비 차단 장치가 필요하다.
+
+이 역할이 Inbox다.
+
+## 3. 비교 대상
+
+### BEFORE: Inbox 미적용
+
+- 동일한 재고 예약 이벤트가 여러 번 들어오면 매번 비즈니스 처리를 수행
+- 중복 메시지가 그대로 재고 예약에 누적 반영됨
+
+### AFTER: Inbox 적용
+
+- `topic + consumerGroup + idempotencyKey`를 기준으로 Inbox claim 수행
+- 처음 본 이벤트만 처리
+- 이미 처리된 동일 이벤트는 duplicate로 간주하고 skip
+
+## 4. 구현 방식
+
+핵심 구현은 아래 두 가지다.
+
+- **Inbox claim**
+  - `product_inbox_event`에 `(topic, consumer_group, idempotency_key)` 유니크 제약을 둠
+  - `INSERT IGNORE` 방식으로 최초 처리 여부를 판별
+
+- **비즈니스 처리 + Inbox 기록의 같은 트랜잭션 처리**
+  - Kafka listener가 이벤트를 받으면
+  - 먼저 Inbox claim을 시도하고
+  - 성공한 경우에만 재고 변경 비즈니스 로직을 수행
+  - duplicate면 비즈니스 처리를 건너뜀
+
+즉 "처리 성공 시에만 Inbox가 남고, Inbox가 없으면 중복 차단 근거도 없다"가 아니라,
+
+- **Inbox claim 성공 -> 처리 진행**
+- **Inbox claim 실패 -> duplicate skip**
+
+구조로 되어 있다.
+
+## 5. 테스트 조건
+
+기준 run:
+
+- `1776241903`
+
+공통 조건:
+
+- 동일한 재고 예약 이벤트 `100회` 중복 발행
+- 상품 재고 `100`
+- 수량 `1`
+- topic: `market.order.stock.changed.experiment.inbox`
+- listener concurrency: `1`
+- Redis 재고 선차감 비활성화
+  - 목적: Redis 중복 방어가 아니라 Inbox 효과만 분리해 보기 위함
+
+### BEFORE
+
+- `PRODUCT_INBOX_ENABLED=false`
+- 동일 이벤트 100건을 그대로 소비
+
+### AFTER
+
+- `PRODUCT_INBOX_ENABLED=true`
+- 동일 이벤트 100건을 Inbox 기준으로 claim 후 중복 skip
+
+## 6. 부하는 어떻게 주었는가
+
+실행 스크립트는 아래다.
+
+- `loadtest/run-product-inbox-before-after-experiment.sh`
+- 실제 오케스트레이션 스크립트: `loadtest/product-inbox-before-after-experiment.js`
+
+이번 실험은 일반 사용자 API 부하가 아니라, experiment API를 이용해 **중복 메시지 소비 상황을 재현하는 구조**다.
+
+흐름은 다음과 같다.
+
+1. `product-service`를 `experiment` 프로필로 재기동
+2. 실험용 상품 1개 생성
+3. run 초기화
+4. 같은 `orderNumber`, 같은 `eventType`, 같은 `productId`, 같은 `quantity`로 `RESERVE` 이벤트를 `100회` 발행
+5. listener가 모든 메시지를 처리하거나 skip할 때까지 summary polling
+6. BEFORE / AFTER 결과를 하나의 JSON으로 저장
+
+즉 입력은:
+
+- **같은 재고 예약 이벤트 100회 중복 발행**
+
+이고,
+
+측정 대상은:
+
+- 실제 처리 수
+- duplicate skip 수
+- 재고 예약 증가량
+- Inbox 기록 수
+
+이다.
+
+## 7. 측정 기준
+
+이번 실험에서 핵심은 "몇 건을 받았나"가 아니라, **몇 건이 실제 비즈니스 처리로 반영됐는가**다.
+
+최종적으로는 아래 값을 본다.
+
+- `processedCount`
+  - 실제 비즈니스 처리까지 수행된 메시지 수
+- `duplicateSkippedCount`
+  - Inbox에 의해 duplicate로 차단된 메시지 수
+- `reservedDelta`
+  - 실험 전후 예약 재고 증가량
+- `appliedReservationCount`
+  - 수량 기준으로 실제 예약이 몇 번 반영됐는지
+- `inboxRecordCount`
+  - 해당 idempotency key로 남은 Inbox row 수
+
+이번 실험에서 중요한 해석은 아래다.
+
+- Inbox가 없으면
+  - `processedCount = 100`
+  - `reservedDelta = 100`
+- Inbox가 있으면
+  - `processedCount = 1`
+  - `duplicateSkippedCount = 99`
+  - `reservedDelta = 1`
+  - `inboxRecordCount = 1`
+
+즉 "동일 이벤트 100회 입력이 실제로 100번 반영되는가, 아니면 1번만 반영되는가"를 보는 실험이다.
+
+## 8. 최종 결과
+
+기준 run:
+
+- `1776241903`
+
+결과는 아래와 같다.
+
+| 항목 | BEFORE (`Inbox 미적용`) | AFTER (`Inbox 적용`) |
+|---|---:|---:|
+| 입력 메시지 수 | 100 | 100 |
+| 실제 처리 수 | 100 | 1 |
+| 중복 차단 수 | 0 | 99 |
+| 재고 예약 반영 수 | 100 | 1 |
+| 예약 재고 증가량 | 100 | 1 |
+| Inbox 기록 수 | 0 | 1 |
+
+해석:
+
+- Inbox가 없으면 동일한 재고 예약 이벤트가 100번 모두 반영됨
+- Inbox를 적용하면 1번만 처리되고 99건은 duplicate로 차단됨
+- 최종적으로 같은 idempotency key에 대한 Inbox 기록은 1건만 남음
+
+즉 이 실험은 아래를 증명한다.
+
+- Outbox 이후 남는 duplicate consume 문제는 실제로 존재한다
+- Inbox는 동일 이벤트의 중복 소비를 비즈니스 처리 전에 차단한다
+- 결과적으로 재고 정합성을 보호할 수 있다
+
+## 9. 왜 single-run 결과로 충분한가
+
+이번 실험은 성능 실험이 아니라 correctness 실험이다.
+
+즉 핵심은:
+
+- 평균 응답시간
+- p95
+- 중앙값
+
+이 아니라,
+
+- duplicate input `100건`
+- actual apply `1건`
+- duplicate skip `99건`
+
+이라는 **정확한 상태 전이 결과**다.
+
+따라서 이 실험은 3회 중앙값보다, **단일 run에서 기대한 correctness가 정확히 나왔는지**가 더 중요하다.
+
+## 10. 면접에서 설명할 때의 핵심 문장
+
+짧게 설명하면 아래가 가장 정확하다.
+
+> Outbox로 유실은 막았지만, recovery 과정에서 duplicate publish 가능성이 남습니다. 그래서 소비 측에 Inbox를 두고 `topic + consumerGroup + idempotencyKey` 기준으로 최초 이벤트만 claim하도록 구성했습니다. 동일한 재고 예약 이벤트를 100회 중복 발행한 실험에서 Inbox 미적용 시 재고 예약이 100회 반영됐지만, 적용 후에는 1회만 반영되고 99건은 중복 차단되는 것을 확인했습니다.
+
+조금 더 기술적으로 설명하면 이렇게 이어갈 수 있다.
+
+> Kafka listener에서 먼저 Inbox claim을 시도하고, claim 성공 시에만 재고 변경 비즈니스 로직을 수행합니다. claim이 실패하면 이미 처리된 동일 이벤트라고 보고 skip합니다. 이 구조 덕분에 at-least-once 발행 특성 아래에서도 소비는 effectively-once에 가깝게 만들 수 있었습니다.
+
+## 11. 이 실험이 증명하는 것과 증명하지 않는 것
+
+### 증명하는 것
+
+- duplicate input에 대한 Inbox의 중복 소비 차단 효과
+- 재고 예약 정합성 보호
+- Outbox 다음 단계로 Inbox가 왜 필요한지
+
+### 증명하지 않는 것
+
+- 일반적인 Kafka 소비 성능
+- 여러 파티션에서의 순서 보장
+- producer duplicate 자체의 원인
+
+이번 실험은 **duplicate consume 차단 효과**만 분리해서 본 것이다.
+
+## 12. 실행 방법
+
+실행 스크립트:
+
+- `loadtest/run-product-inbox-before-after-experiment.sh`
+
+실행 예시:
+
+```bash
+RUN_ID=$(date +%s) \
+EXPERIMENT_DUPLICATE_COUNT=100 \
+bash loadtest/run-product-inbox-before-after-experiment.sh
+```
+
+결과 파일:
+
+- `loadtest/results/product-inbox-before-after-<run_id>.json`
+
+이 JSON 하나로 BEFORE/AFTER 표를 만들 수 있다.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -266,6 +266,31 @@ Key comparison fields:
 - `validations.beforeLostEventsDetected`
 - `validations.afterNoEventLoss`
 
+Run the inbox duplicate-consumption comparison with one wrapper.
+
+```bash
+bash loadtest/run-product-inbox-before-after-experiment.sh
+```
+
+This wrapper runs two phases against the same duplicate `RESERVE` event workload:
+
+- `before`: `product.inbox.enabled=false`
+- `after`: `product.inbox.enabled=true`
+
+The wrapper creates one experiment product per phase, publishes the same stock-change event repeatedly to a dedicated experiment topic, then compares reserved stock changes and inbox record counts.
+
+Key comparison fields:
+
+- `before.summary.processedCount`
+- `before.summary.duplicateSkippedCount`
+- `before.summary.reservedDelta`
+- `before.summary.appliedReservationCount`
+- `after.summary.processedCount`
+- `after.summary.duplicateSkippedCount`
+- `after.summary.reservedDelta`
+- `after.summary.appliedReservationCount`
+- `after.summary.inboxRecordCount`
+
 Reset the product experiment state cleanly before each run.
 
 ```bash

--- a/loadtest/product-inbox-before-after-experiment.js
+++ b/loadtest/product-inbox-before-after-experiment.js
@@ -1,0 +1,117 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+};
+
+const productServiceBaseUrl = (__ENV.PRODUCT_SERVICE_BASE_URL || 'http://product-service:8082').replace(/\/$/, '');
+const runId = __ENV.RUN_ID || `${Date.now()}`;
+const phase = __ENV.EXPERIMENT_PHASE || 'before';
+const phaseRunId = `${runId}-${phase}`;
+const topic = __ENV.EXPERIMENT_TOPIC || 'market.order.stock.changed.experiment.inbox';
+const consumerGroup = __ENV.EXPERIMENT_CONSUMER_GROUP || `product-inbox-experiment-${phaseRunId}`;
+const duplicateCount = Number(__ENV.EXPERIMENT_DUPLICATE_COUNT || 100);
+const quantity = Number(__ENV.EXPERIMENT_QUANTITY || 1);
+const stock = Number(__ENV.EXPERIMENT_STOCK || 100);
+const pollIntervalMs = Number(__ENV.EXPERIMENT_POLL_INTERVAL_MS || 1000);
+const pollTimeoutSeconds = Number(__ENV.EXPERIMENT_POLL_TIMEOUT_SECONDS || 120);
+
+function request(method, path, body = null, expectedStatus = 200) {
+  const url = `${productServiceBaseUrl}${path}`;
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    timeout: '180s',
+  };
+
+  const response = body === null
+    ? http.request(method, url, null, params)
+    : http.request(method, url, JSON.stringify(body), params);
+
+  check(response, {
+    [`${method} ${path} -> ${expectedStatus}`]: (res) => res.status === expectedStatus,
+  });
+
+  if (response.status !== expectedStatus) {
+    throw new Error(`Unexpected status for ${method} ${path}: ${response.status} body=${response.body}`);
+  }
+
+  return response;
+}
+
+function createProduct() {
+  const response = request('POST', '/api/v1/experiments/stock/products', {
+    sellerId: 1,
+    name: `inbox-exp-${phaseRunId}`,
+    price: 10000,
+    salePrice: 10000,
+    category: 'KEYBOARD',
+    stock,
+  }, 201);
+
+  return response.json();
+}
+
+function pollSummary() {
+  const deadline = Date.now() + (pollTimeoutSeconds * 1000);
+
+  while (Date.now() < deadline) {
+    const response = request('GET', `/api/v1/experiments/inbox/runs/${phaseRunId}/summary`);
+    const summary = response.json();
+
+    if (summary.completed === true) {
+      return summary;
+    }
+
+    sleep(pollIntervalMs / 1000);
+  }
+
+  const finalResponse = request('GET', `/api/v1/experiments/inbox/runs/${phaseRunId}/summary`);
+  throw new Error(`Inbox experiment polling timed out. summary=${finalResponse.body}`);
+}
+
+export default function () {
+  const product = createProduct();
+  const orderNumber = `inbox-exp:${phaseRunId}:order-1`;
+  const startedAtMillis = Date.now();
+
+  request('POST', '/api/v1/experiments/inbox/runs/reset', {
+    runId: phaseRunId,
+    productId: product.productId,
+    orderNumber,
+    eventType: 'RESERVE',
+    quantity,
+    expectedMessageCount: duplicateCount,
+    topic,
+    consumerGroup,
+    initialStock: product.stock,
+    initialReservedStock: product.reservedStock,
+    startedAtMillis,
+  }, 204);
+
+  request('POST', '/api/v1/experiments/inbox/runs/publish', {
+    runId: phaseRunId,
+    topic,
+    orderNumber,
+    eventType: 'RESERVE',
+    productId: product.productId,
+    quantity,
+    duplicateCount,
+  }, 202);
+
+  const summary = pollSummary();
+
+  console.log(`phase=${phase}`);
+  console.log(`phase_run_id=${phaseRunId}`);
+  console.log(`product_id=${product.productId}`);
+  console.log(`expected_messages=${summary.expectedMessageCount}`);
+  console.log(`processed=${summary.processedCount}`);
+  console.log(`duplicate_skipped=${summary.duplicateSkippedCount}`);
+  console.log(`failed=${summary.failedCount}`);
+  console.log(`reserved_delta=${summary.reservedDelta}`);
+  console.log(`applied_reservation_count=${summary.appliedReservationCount}`);
+  console.log(`inbox_record_count=${summary.inboxRecordCount}`);
+}

--- a/loadtest/run-product-inbox-before-after-experiment.sh
+++ b/loadtest/run-product-inbox-before-after-experiment.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd jq
+
+RUN_ID="${RUN_ID:-$(date +%s)}"
+PRODUCT_SERVICE_BASE_URL="${PRODUCT_SERVICE_BASE_URL:-http://product-service:8082}"
+PRODUCT_SERVICE_HEALTH_URL="${PRODUCT_SERVICE_HEALTH_URL:-${PRODUCT_SERVICE_BASE_URL}/actuator/health}"
+WAIT_MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS:-40}"
+WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS:-2}"
+WAIT_STABLE_SUCCESSES="${WAIT_STABLE_SUCCESSES:-3}"
+
+EXPERIMENT_DUPLICATE_COUNT="${EXPERIMENT_DUPLICATE_COUNT:-100}"
+EXPERIMENT_QUANTITY="${EXPERIMENT_QUANTITY:-1}"
+EXPERIMENT_STOCK="${EXPERIMENT_STOCK:-100}"
+EXPERIMENT_POLL_INTERVAL_MS="${EXPERIMENT_POLL_INTERVAL_MS:-1000}"
+EXPERIMENT_POLL_TIMEOUT_SECONDS="${EXPERIMENT_POLL_TIMEOUT_SECONDS:-120}"
+INBOX_EXPERIMENT_TOPIC="${PRODUCT_INBOX_EXPERIMENT_TOPIC:-market.order.stock.changed.experiment.inbox}"
+
+BEFORE_CONSUMER_GROUP="product-inbox-experiment-${RUN_ID}-before"
+AFTER_CONSUMER_GROUP="product-inbox-experiment-${RUN_ID}-after"
+
+RESULT_BEFORE="loadtest/results/product-inbox-before-${RUN_ID}.json"
+RESULT_AFTER="loadtest/results/product-inbox-after-${RUN_ID}.json"
+RESULT_COMBINED="loadtest/results/product-inbox-before-after-${RUN_ID}.json"
+
+wait_for_product_service() {
+  docker compose --profile loadtest run --no-deps --rm \
+    -e WAIT_URL="${PRODUCT_SERVICE_HEALTH_URL}" \
+    -e WAIT_MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS}" \
+    -e WAIT_SLEEP_SECONDS="${WAIT_SLEEP_SECONDS}" \
+    -e WAIT_STABLE_SUCCESSES="${WAIT_STABLE_SUCCESSES}" \
+    k6 run /scripts/wait-http.js >/dev/null
+}
+
+restart_product_service() {
+  local phase="$1"
+  local inbox_enabled="$2"
+  local consumer_group="$3"
+
+  echo "phase=${phase}"
+  echo "product_inbox_enabled=${inbox_enabled}"
+  echo "product_inbox_experiment_topic=${INBOX_EXPERIMENT_TOPIC}"
+  echo "product_inbox_experiment_consumer_group=${consumer_group}"
+
+  PRODUCT_SERVICE_PROFILES_ACTIVE=docker,experiment \
+  PRODUCT_INBOX_ENABLED="${inbox_enabled}" \
+  PRODUCT_STOCK_REDIS_ENABLED=false \
+  PRODUCT_KAFKA_LISTENER_CONCURRENCY=1 \
+  PRODUCT_INBOX_EXPERIMENT_TOPIC="${INBOX_EXPERIMENT_TOPIC}" \
+  PRODUCT_INBOX_EXPERIMENT_CONSUMER_GROUP="${consumer_group}" \
+  docker compose up -d --build product-service
+
+  wait_for_product_service
+}
+
+run_phase() {
+  local phase="$1"
+  local inbox_enabled="$2"
+  local consumer_group="$3"
+  local result_path="$4"
+  local phase_run_id="${RUN_ID}-${phase}"
+  local summary_json
+
+  restart_product_service "${phase}" "${inbox_enabled}" "${consumer_group}"
+
+  docker compose --profile loadtest run --no-deps --rm \
+    -e RUN_ID="${RUN_ID}" \
+    -e EXPERIMENT_PHASE="${phase}" \
+    -e PRODUCT_SERVICE_BASE_URL="${PRODUCT_SERVICE_BASE_URL}" \
+    -e EXPERIMENT_TOPIC="${INBOX_EXPERIMENT_TOPIC}" \
+    -e EXPERIMENT_CONSUMER_GROUP="${consumer_group}" \
+    -e EXPERIMENT_DUPLICATE_COUNT="${EXPERIMENT_DUPLICATE_COUNT}" \
+    -e EXPERIMENT_QUANTITY="${EXPERIMENT_QUANTITY}" \
+    -e EXPERIMENT_STOCK="${EXPERIMENT_STOCK}" \
+    -e EXPERIMENT_POLL_INTERVAL_MS="${EXPERIMENT_POLL_INTERVAL_MS}" \
+    -e EXPERIMENT_POLL_TIMEOUT_SECONDS="${EXPERIMENT_POLL_TIMEOUT_SECONDS}" \
+    k6 run /scripts/product-inbox-before-after-experiment.js
+
+  summary_json="$(docker compose exec -T product-service \
+    curl -s "http://localhost:8082/api/v1/experiments/inbox/runs/${phase_run_id}/summary")"
+
+  jq -n \
+    --arg runId "${RUN_ID}" \
+    --arg phase "${phase}" \
+    --arg phaseRunId "${phase_run_id}" \
+    --arg inboxEnabled "${inbox_enabled}" \
+    --arg topic "${INBOX_EXPERIMENT_TOPIC}" \
+    --arg consumerGroup "${consumer_group}" \
+    --argjson duplicateCount "${EXPERIMENT_DUPLICATE_COUNT}" \
+    --argjson quantity "${EXPERIMENT_QUANTITY}" \
+    --argjson stock "${EXPERIMENT_STOCK}" \
+    --argjson summary "${summary_json}" \
+    '
+    {
+      runId: $runId,
+      phase: $phase,
+      phaseRunId: $phaseRunId,
+      inboxEnabled: ($inboxEnabled == "true"),
+      topic: $topic,
+      consumerGroup: $consumerGroup,
+      config: {
+        duplicateCount: $duplicateCount,
+        quantity: $quantity,
+        stock: $stock
+      },
+      summary: $summary
+    }
+    ' > "${result_path}"
+}
+
+docker compose up -d mysql redpanda redis
+
+run_phase "before" "false" "${BEFORE_CONSUMER_GROUP}" "${RESULT_BEFORE}"
+run_phase "after" "true" "${AFTER_CONSUMER_GROUP}" "${RESULT_AFTER}"
+
+jq -n \
+  --arg runId "${RUN_ID}" \
+  --arg topic "${INBOX_EXPERIMENT_TOPIC}" \
+  --arg beforeConsumerGroup "${BEFORE_CONSUMER_GROUP}" \
+  --arg afterConsumerGroup "${AFTER_CONSUMER_GROUP}" \
+  --argjson duplicateCount "${EXPERIMENT_DUPLICATE_COUNT}" \
+  --argjson quantity "${EXPERIMENT_QUANTITY}" \
+  --argjson stock "${EXPERIMENT_STOCK}" \
+  --slurpfile before "${RESULT_BEFORE}" \
+  --slurpfile after "${RESULT_AFTER}" \
+  '
+  {
+    runId: $runId,
+    config: {
+      duplicateCount: $duplicateCount,
+      quantity: $quantity,
+      stock: $stock,
+      topic: $topic,
+      beforeConsumerGroup: $beforeConsumerGroup,
+      afterConsumerGroup: $afterConsumerGroup
+    },
+    before: $before[0],
+    after: $after[0]
+  }
+  ' > "${RESULT_COMBINED}"
+
+cat <<EOF
+run_id=${RUN_ID}
+before_result=${RESULT_BEFORE}
+after_result=${RESULT_AFTER}
+combined_result=${RESULT_COMBINED}
+EOF

--- a/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentController.java
+++ b/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentController.java
@@ -1,0 +1,41 @@
+package com.thock.back.product.experiment;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Profile("experiment")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/experiments/inbox")
+public class ProductInboxExperimentController {
+
+    private final ProductInboxExperimentService productInboxExperimentService;
+
+    @PostMapping("/runs/reset")
+    public ResponseEntity<Void> reset(@Valid @RequestBody ProductInboxExperimentResetRequest request) {
+        productInboxExperimentService.reset(request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/runs/publish")
+    public ResponseEntity<ProductInboxExperimentPublishResponse> publish(
+            @Valid @RequestBody ProductInboxExperimentPublishRequest request
+    ) {
+        ProductInboxExperimentPublishResponse response = productInboxExperimentService.publish(request);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
+    }
+
+    @GetMapping("/runs/{runId}/summary")
+    public ResponseEntity<ProductInboxExperimentSummaryResponse> getSummary(@PathVariable String runId) {
+        return ResponseEntity.ok(productInboxExperimentService.getSummary(runId));
+    }
+}

--- a/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentListener.java
+++ b/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentListener.java
@@ -1,0 +1,77 @@
+package com.thock.back.product.experiment;
+
+import com.thock.back.product.app.ProductStockService;
+import com.thock.back.product.in.idempotency.ProductInboundEventIdempotencyKeyResolver;
+import com.thock.back.shared.market.event.MarketOrderStockChangedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("experiment")
+@RequiredArgsConstructor
+public class ProductInboxExperimentListener {
+
+    private final ProductStockService productStockService;
+    private final ProductInboundEventIdempotencyKeyResolver idempotencyKeyResolver;
+    private final ProductInboxExperimentRecorder recorder;
+
+    @Value("${product.inbox-experiment.topic:market.order.stock.changed.experiment.inbox}")
+    private String experimentTopic;
+
+    @Value("${product.inbox-experiment.consumer-group:product-inbox-experiment}")
+    private String consumerGroup;
+
+    @KafkaListener(
+            topics = "${product.inbox-experiment.topic:market.order.stock.changed.experiment.inbox}",
+            groupId = "${product.inbox-experiment.consumer-group:product-inbox-experiment}",
+            containerFactory = "productKafkaListenerContainerFactory"
+    )
+    public void handle(
+            MarketOrderStockChangedEvent event,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(value = KafkaHeaders.RECEIVED_KEY, required = false) String messageKey
+    ) {
+        String runId = ProductInboxExperimentRecorder.extractRunId(event.orderNumber());
+        if (runId == null) {
+            log.debug("Inbox experiment event ignored. orderNumber={}", event.orderNumber());
+            return;
+        }
+
+        long handledAtMillis = System.currentTimeMillis();
+        String idempotencyKey = idempotencyKeyResolver.stockChanged(event);
+
+        try {
+            boolean processed = productStockService.handleKafka(
+                    event,
+                    experimentTopic,
+                    idempotencyKey,
+                    consumerGroup
+            );
+
+            if (!processed) {
+                recorder.recordDuplicate(runId, handledAtMillis);
+                return;
+            }
+
+            recorder.recordProcessed(runId, handledAtMillis);
+        } catch (Exception e) {
+            recorder.recordFailure(runId, handledAtMillis);
+            log.error(
+                    "Inbox experiment event failed. runId={}, orderNumber={}, partition={}, key={}",
+                    runId,
+                    event.orderNumber(),
+                    partition,
+                    messageKey,
+                    e
+            );
+            throw e;
+        }
+    }
+}

--- a/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentPublishRequest.java
+++ b/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentPublishRequest.java
@@ -1,0 +1,32 @@
+package com.thock.back.product.experiment;
+
+import com.thock.back.shared.market.domain.StockEventType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ProductInboxExperimentPublishRequest(
+        @NotBlank
+        String runId,
+
+        @NotBlank
+        String topic,
+
+        @NotBlank
+        String orderNumber,
+
+        @NotNull
+        StockEventType eventType,
+
+        @NotNull
+        Long productId,
+
+        @NotNull
+        @Min(1)
+        Integer quantity,
+
+        @NotNull
+        @Min(1)
+        Integer duplicateCount
+) {
+}

--- a/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentPublishResponse.java
+++ b/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentPublishResponse.java
@@ -1,0 +1,9 @@
+package com.thock.back.product.experiment;
+
+public record ProductInboxExperimentPublishResponse(
+        String runId,
+        int publishedCount,
+        long publishStartedAtMillis,
+        long publishFinishedAtMillis
+) {
+}

--- a/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentRecorder.java
+++ b/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentRecorder.java
@@ -1,0 +1,260 @@
+package com.thock.back.product.experiment;
+
+import com.thock.back.shared.market.domain.StockEventType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+@Component
+@Profile("experiment")
+public class ProductInboxExperimentRecorder {
+
+    private static final String ORDER_PREFIX = "inbox-exp:";
+
+    private final ConcurrentMap<String, RunState> runs = new ConcurrentHashMap<>();
+
+    public void reset(ProductInboxExperimentResetRequest request) {
+        runs.put(
+                request.runId(),
+                new RunState(
+                        request.runId(),
+                        request.productId(),
+                        request.orderNumber(),
+                        request.eventType(),
+                        request.quantity(),
+                        request.expectedMessageCount(),
+                        request.topic(),
+                        request.consumerGroup(),
+                        request.initialStock(),
+                        request.initialReservedStock(),
+                        request.startedAtMillis()
+                )
+        );
+    }
+
+    public void recordProcessed(String runId, long handledAtMillis) {
+        RunState runState = runs.get(runId);
+        if (runState == null) {
+            log.debug("Inbox experiment run not found. runId={}", runId);
+            return;
+        }
+
+        runState.recordProcessed(handledAtMillis);
+    }
+
+    public void recordDuplicate(String runId, long handledAtMillis) {
+        RunState runState = runs.get(runId);
+        if (runState == null) {
+            log.debug("Inbox experiment run not found for duplicate. runId={}", runId);
+            return;
+        }
+
+        runState.recordDuplicate(handledAtMillis);
+    }
+
+    public void recordFailure(String runId, long handledAtMillis) {
+        RunState runState = runs.get(runId);
+        if (runState == null) {
+            log.debug("Inbox experiment run not found for failure. runId={}", runId);
+            return;
+        }
+
+        runState.recordFailure(handledAtMillis);
+    }
+
+    public RunSnapshot getSnapshot(String runId) {
+        RunState runState = runs.get(runId);
+        if (runState == null) {
+            return RunSnapshot.empty(runId);
+        }
+
+        return runState.toSnapshot();
+    }
+
+    public static boolean isExperimentOrderNumber(String orderNumber) {
+        return orderNumber != null && orderNumber.startsWith(ORDER_PREFIX);
+    }
+
+    public static String extractRunId(String orderNumber) {
+        if (!isExperimentOrderNumber(orderNumber)) {
+            return null;
+        }
+
+        String[] parts = orderNumber.split(":");
+        if (parts.length < 3) {
+            return null;
+        }
+
+        return parts[1];
+    }
+
+    public static String createOrderNumber(String runId) {
+        return ORDER_PREFIX + runId + ":order-1";
+    }
+
+    public record RunSnapshot(
+            String runId,
+            Long productId,
+            String orderNumber,
+            StockEventType eventType,
+            int quantity,
+            int expectedMessageCount,
+            String topic,
+            String consumerGroup,
+            int processedCount,
+            int duplicateSkippedCount,
+            int failedCount,
+            long startedAtMillis,
+            Long firstHandledAtMillis,
+            Long lastHandledAtMillis,
+            Long totalDurationMillis,
+            int initialStock,
+            int initialReservedStock,
+            boolean completed
+    ) {
+        static RunSnapshot empty(String runId) {
+            return new RunSnapshot(
+                    runId,
+                    null,
+                    null,
+                    null,
+                    0,
+                    0,
+                    null,
+                    null,
+                    0,
+                    0,
+                    0,
+                    0L,
+                    null,
+                    null,
+                    null,
+                    0,
+                    0,
+                    false
+            );
+        }
+    }
+
+    private static final class RunState {
+        private final String runId;
+        private final Long productId;
+        private final String orderNumber;
+        private final StockEventType eventType;
+        private final int quantity;
+        private final int expectedMessageCount;
+        private final String topic;
+        private final String consumerGroup;
+        private final int initialStock;
+        private final int initialReservedStock;
+        private final long startedAtMillis;
+        private final AtomicInteger processedCount = new AtomicInteger();
+        private final AtomicInteger duplicateSkippedCount = new AtomicInteger();
+        private final AtomicInteger failedCount = new AtomicInteger();
+        private final AtomicLong firstHandledAtMillis = new AtomicLong(Long.MAX_VALUE);
+        private final AtomicLong lastHandledAtMillis = new AtomicLong(0L);
+
+        private RunState(
+                String runId,
+                Long productId,
+                String orderNumber,
+                StockEventType eventType,
+                int quantity,
+                int expectedMessageCount,
+                String topic,
+                String consumerGroup,
+                int initialStock,
+                int initialReservedStock,
+                long startedAtMillis
+        ) {
+            this.runId = runId;
+            this.productId = productId;
+            this.orderNumber = orderNumber;
+            this.eventType = eventType;
+            this.quantity = quantity;
+            this.expectedMessageCount = expectedMessageCount;
+            this.topic = topic;
+            this.consumerGroup = consumerGroup;
+            this.initialStock = initialStock;
+            this.initialReservedStock = initialReservedStock;
+            this.startedAtMillis = startedAtMillis;
+        }
+
+        private void recordProcessed(long handledAtMillis) {
+            processedCount.incrementAndGet();
+            updateHandledAt(handledAtMillis);
+        }
+
+        private void recordDuplicate(long handledAtMillis) {
+            duplicateSkippedCount.incrementAndGet();
+            updateHandledAt(handledAtMillis);
+        }
+
+        private void recordFailure(long handledAtMillis) {
+            failedCount.incrementAndGet();
+            updateHandledAt(handledAtMillis);
+        }
+
+        private void updateHandledAt(long handledAtMillis) {
+            updateMin(firstHandledAtMillis, handledAtMillis);
+            updateMax(lastHandledAtMillis, handledAtMillis);
+        }
+
+        private RunSnapshot toSnapshot() {
+            Long firstHandled = firstHandledAtMillis.get() == Long.MAX_VALUE
+                    ? null
+                    : firstHandledAtMillis.get();
+            Long lastHandled = lastHandledAtMillis.get() == 0L
+                    ? null
+                    : lastHandledAtMillis.get();
+            Long totalDuration = lastHandled == null
+                    ? null
+                    : Math.max(lastHandled - startedAtMillis, 0L);
+
+            return new RunSnapshot(
+                    runId,
+                    productId,
+                    orderNumber,
+                    eventType,
+                    quantity,
+                    expectedMessageCount,
+                    topic,
+                    consumerGroup,
+                    processedCount.get(),
+                    duplicateSkippedCount.get(),
+                    failedCount.get(),
+                    startedAtMillis,
+                    firstHandled,
+                    lastHandled,
+                    totalDuration,
+                    initialStock,
+                    initialReservedStock,
+                    isCompleted()
+            );
+        }
+
+        private boolean isCompleted() {
+            return processedCount.get() + duplicateSkippedCount.get() + failedCount.get() >= expectedMessageCount;
+        }
+
+        private static void updateMin(AtomicLong target, long candidate) {
+            long current = target.get();
+            while (candidate < current && !target.compareAndSet(current, candidate)) {
+                current = target.get();
+            }
+        }
+
+        private static void updateMax(AtomicLong target, long candidate) {
+            long current = target.get();
+            while (candidate > current && !target.compareAndSet(current, candidate)) {
+                current = target.get();
+            }
+        }
+    }
+}

--- a/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentResetRequest.java
+++ b/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentResetRequest.java
@@ -1,0 +1,44 @@
+package com.thock.back.product.experiment;
+
+import com.thock.back.shared.market.domain.StockEventType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ProductInboxExperimentResetRequest(
+        @NotBlank
+        String runId,
+
+        @NotNull
+        Long productId,
+
+        @NotBlank
+        String orderNumber,
+
+        @NotNull
+        StockEventType eventType,
+
+        @NotNull
+        @Min(1)
+        Integer quantity,
+
+        @NotNull
+        @Min(1)
+        Integer expectedMessageCount,
+
+        @NotBlank
+        String topic,
+
+        @NotBlank
+        String consumerGroup,
+
+        @NotNull
+        Integer initialStock,
+
+        @NotNull
+        Integer initialReservedStock,
+
+        @NotNull
+        Long startedAtMillis
+) {
+}

--- a/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentService.java
+++ b/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentService.java
@@ -1,0 +1,137 @@
+package com.thock.back.product.experiment;
+
+import com.thock.back.global.exception.CustomException;
+import com.thock.back.global.exception.ErrorCode;
+import com.thock.back.product.domain.entity.Product;
+import com.thock.back.product.in.idempotency.ProductInboundEventIdempotencyKeyResolver;
+import com.thock.back.product.messaging.inbox.ProductInboxEventRepository;
+import com.thock.back.product.out.ProductRepository;
+import com.thock.back.shared.market.dto.StockOrderItemDto;
+import com.thock.back.shared.market.event.MarketOrderStockChangedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@Profile("experiment")
+@RequiredArgsConstructor
+public class ProductInboxExperimentService {
+
+    private final ProductInboxExperimentRecorder recorder;
+    private final ProductRepository productRepository;
+    private final ProductInboxEventRepository productInboxEventRepository;
+    private final ProductInboundEventIdempotencyKeyResolver idempotencyKeyResolver;
+    private final @Qualifier("productKafkaTemplate") KafkaTemplate<String, Object> productKafkaTemplate;
+
+    public void reset(ProductInboxExperimentResetRequest request) {
+        recorder.reset(request);
+    }
+
+    public ProductInboxExperimentPublishResponse publish(ProductInboxExperimentPublishRequest request) {
+        long publishStartedAtMillis = System.currentTimeMillis();
+        StockOrderItemDto item = new StockOrderItemDto(request.productId(), request.quantity());
+        MarketOrderStockChangedEvent event = new MarketOrderStockChangedEvent(
+                request.orderNumber(),
+                request.eventType(),
+                List.of(item)
+        );
+
+        CompletableFuture<?>[] futures = new CompletableFuture<?>[request.duplicateCount()];
+        for (int index = 0; index < request.duplicateCount(); index += 1) {
+            futures[index] = productKafkaTemplate.send(request.topic(), request.orderNumber(), event);
+        }
+
+        CompletableFuture.allOf(futures).join();
+        long publishFinishedAtMillis = System.currentTimeMillis();
+
+        return new ProductInboxExperimentPublishResponse(
+                request.runId(),
+                request.duplicateCount(),
+                publishStartedAtMillis,
+                publishFinishedAtMillis
+        );
+    }
+
+    public ProductInboxExperimentSummaryResponse getSummary(String runId) {
+        ProductInboxExperimentRecorder.RunSnapshot snapshot = recorder.getSnapshot(runId);
+
+        if (snapshot.productId() == null) {
+            return new ProductInboxExperimentSummaryResponse(
+                    runId,
+                    null,
+                    null,
+                    null,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0L,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    0L,
+                    false
+            );
+        }
+
+        Product product = productRepository.findById(snapshot.productId())
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        MarketOrderStockChangedEvent event = new MarketOrderStockChangedEvent(
+                snapshot.orderNumber(),
+                snapshot.eventType(),
+                List.of(new StockOrderItemDto(snapshot.productId(), snapshot.quantity()))
+        );
+        String idempotencyKey = idempotencyKeyResolver.stockChanged(event);
+
+        long inboxRecordCount = productInboxEventRepository.countByTopicAndIdempotencyKey(snapshot.topic(), idempotencyKey);
+
+        int finalAvailableStock = product.getStock() - product.getReservedStock();
+        int initialAvailableStock = snapshot.initialStock() - snapshot.initialReservedStock();
+        int reservedDelta = product.getReservedStock() - snapshot.initialReservedStock();
+        int availableDelta = initialAvailableStock - finalAvailableStock;
+        int appliedReservationCount = snapshot.quantity() <= 0 ? 0 : reservedDelta / snapshot.quantity();
+
+        return new ProductInboxExperimentSummaryResponse(
+                snapshot.runId(),
+                snapshot.productId(),
+                snapshot.orderNumber(),
+                snapshot.eventType(),
+                snapshot.quantity(),
+                snapshot.expectedMessageCount(),
+                snapshot.processedCount(),
+                snapshot.duplicateSkippedCount(),
+                snapshot.failedCount(),
+                snapshot.startedAtMillis(),
+                snapshot.firstHandledAtMillis(),
+                snapshot.lastHandledAtMillis(),
+                snapshot.totalDurationMillis(),
+                snapshot.initialStock(),
+                snapshot.initialReservedStock(),
+                initialAvailableStock,
+                product.getStock(),
+                product.getReservedStock(),
+                finalAvailableStock,
+                reservedDelta,
+                availableDelta,
+                appliedReservationCount,
+                inboxRecordCount,
+                snapshot.completed()
+        );
+    }
+}

--- a/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentSummaryResponse.java
+++ b/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentSummaryResponse.java
@@ -1,0 +1,31 @@
+package com.thock.back.product.experiment;
+
+import com.thock.back.shared.market.domain.StockEventType;
+
+public record ProductInboxExperimentSummaryResponse(
+        String runId,
+        Long productId,
+        String orderNumber,
+        StockEventType eventType,
+        int quantity,
+        int expectedMessageCount,
+        int processedCount,
+        int duplicateSkippedCount,
+        int failedCount,
+        long startedAtMillis,
+        Long firstHandledAtMillis,
+        Long lastHandledAtMillis,
+        Long totalDurationMillis,
+        Integer initialStock,
+        Integer initialReservedStock,
+        Integer initialAvailableStock,
+        Integer finalStock,
+        Integer finalReservedStock,
+        Integer finalAvailableStock,
+        Integer reservedDelta,
+        Integer availableDelta,
+        Integer appliedReservationCount,
+        long inboxRecordCount,
+        boolean completed
+) {
+}

--- a/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentTopicConfig.java
+++ b/product-service/src/main/java/com/thock/back/product/experiment/ProductInboxExperimentTopicConfig.java
@@ -1,0 +1,27 @@
+package com.thock.back.product.experiment;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+@Profile("experiment")
+public class ProductInboxExperimentTopicConfig {
+
+    @Value("${product.inbox-experiment.topic:market.order.stock.changed.experiment.inbox}")
+    private String topicName;
+
+    @Value("${product.inbox-experiment.replicas:1}")
+    private int replicas;
+
+    @Bean
+    public NewTopic productInboxExperimentTopic() {
+        return TopicBuilder.name(topicName)
+                .partitions(1)
+                .replicas(replicas)
+                .build();
+    }
+}

--- a/product-service/src/main/java/com/thock/back/product/messaging/inbox/ProductInboxEventRepository.java
+++ b/product-service/src/main/java/com/thock/back/product/messaging/inbox/ProductInboxEventRepository.java
@@ -11,6 +11,10 @@ import java.util.List;
 
 public interface ProductInboxEventRepository extends JpaRepository<ProductInboxEvent, Long> {
 
+    long countByTopicAndConsumerGroupAndIdempotencyKey(String topic, String consumerGroup, String idempotencyKey);
+
+    long countByTopicAndIdempotencyKey(String topic, String idempotencyKey);
+
     // idempotencyKey + topic + consumerGroup -> DB 유니크 제약으로 검증
     @Modifying
     @Query(

--- a/product-service/src/main/resources/application-experiment.yml
+++ b/product-service/src/main/resources/application-experiment.yml
@@ -10,6 +10,10 @@ product:
       name: ${PRODUCT_PARTITION_EXPERIMENT_MULTI_TOPIC:market.order.stock.changed.experiment.multi}
       partitions: ${PRODUCT_PARTITION_EXPERIMENT_MULTI_TOPIC_PARTITIONS:3}
     replicas: ${PRODUCT_PARTITION_EXPERIMENT_TOPIC_REPLICAS:1}
+  inbox-experiment:
+    topic: ${PRODUCT_INBOX_EXPERIMENT_TOPIC:market.order.stock.changed.experiment.inbox}
+    consumer-group: ${PRODUCT_INBOX_EXPERIMENT_CONSUMER_GROUP:product-inbox-experiment}
+    replicas: ${PRODUCT_INBOX_EXPERIMENT_TOPIC_REPLICAS:1}
   event:
     publish-mode: ${PRODUCT_EVENT_PUBLISH_MODE:outbox}
     direct:


### PR DESCRIPTION
## 관련 이슈
Closes #63 

## 변경 내용
- `product-service`에 Inbox 중복 소비 차단 실험용 topic, listener, recorder, summary API를 추가했습니다.
- 동일한 재고 예약 이벤트를 여러 번 발행해 duplicate consume 상황을 재현할 수 있는 실험용 publish/reset API를 추가했습니다.
- `Inbox 미적용` / `Inbox 적용` BEFORE/AFTER를 한 번에 비교할 수 있도록 `run-product-inbox-before-after-experiment.sh`와 `product-inbox-before-after-experiment.js`를 추가했습니다.
- run_id 기준으로 실제 처리 수, 중복 차단 수, 예약 재고 증가량, Inbox 기록 수를 집계하는 비교 로직을 추가했습니다.
- `product-inbox-before-after-analysis.md`에 테스트 조건, 측정 기준, Outbox 이후 Inbox가 필요한 이유를 정리했습니다.
- `loadtest/README.md`에 실행 방법과 결과 확인 방법을 추가했습니다.

## 확인 내용
- `RUN_ID=1776241903 bash loadtest/run-product-inbox-before-after-experiment.sh` 실행 기준
- BEFORE `Inbox 미적용`
  - `processedCount = 100`
  - `duplicateSkippedCount = 0`
  - `reservedDelta = 100`
  - `appliedReservationCount = 100`
  - `inboxRecordCount = 0`
- AFTER `Inbox 적용`
  - `processedCount = 1`
  - `duplicateSkippedCount = 99`
  - `reservedDelta = 1`
  - `appliedReservationCount = 1`
  - `inboxRecordCount = 1`
- 동일 이벤트 100회 중복 입력 시 Inbox 미적용에서는 재고 예약이 100회 반영되고, 적용 후에는 1회만 반영되며 99건이 차단되는 것을 확인했습니다.
