### PR TITLE
[FEAT] 재고 예약 실패 주문 보상 흐름 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,28 +8,8 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:8.0
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: test_db
-          MYSQL_USER: test
-          MYSQL_PASSWORD: test
-          TZ: Asia/Seoul
-        options: >-
-          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=10
-
     env:
       JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
-      TEST_DB_URL: jdbc:mysql://127.0.0.1:3306/test_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-      TEST_DB_USERNAME: test
-      TEST_DB_PASSWORD: test
 
     steps:
       - name: Checkout code

--- a/common/src/main/java/com/thock/back/global/kafka/KafkaTopics.java
+++ b/common/src/main/java/com/thock/back/global/kafka/KafkaTopics.java
@@ -19,6 +19,7 @@ public class KafkaTopics {
 
     // Product events
     public static final String PRODUCT_CHANGED = "product.changed";
+    public static final String PRODUCT_STOCK_RESERVATION_FAILED = "product.stock.reservation.failed";
 
     // Payment events
     public static final String PAYMENT_REFUND_COMPLETED = "payment.refund.completed";

--- a/common/src/main/java/com/thock/back/shared/market/domain/CancelReasonType.java
+++ b/common/src/main/java/com/thock/back/shared/market/domain/CancelReasonType.java
@@ -11,6 +11,7 @@ public enum CancelReasonType {
     // 시스템에서 취소하는 경우
     PAYMENT_TIMEOUT("결제 시간 초과"),
     PAYMENT_CANCELLED_BY_USER("사용자 결제 취소"),
+    STOCK_RESERVATION_FAILED("재고 예약 실패"),
 
     // 사용자가 취소하는 경우
     CHANGE_OF_MIND("단순 변심"),
@@ -32,7 +33,8 @@ public enum CancelReasonType {
      * 시스템에 의한 취소인지 확인
      */
     public boolean isSystemCancellation() {
-        return this == PAYMENT_TIMEOUT || this == PAYMENT_CANCELLED_BY_USER;
+        return this == PAYMENT_TIMEOUT ||
+                this == PAYMENT_CANCELLED_BY_USER ||
+                this == STOCK_RESERVATION_FAILED;
     }
-
 }

--- a/common/src/main/java/com/thock/back/shared/product/event/ProductStockReservationFailedEvent.java
+++ b/common/src/main/java/com/thock/back/shared/product/event/ProductStockReservationFailedEvent.java
@@ -1,0 +1,13 @@
+package com.thock.back.shared.product.event;
+
+import com.thock.back.shared.market.dto.StockOrderItemDto;
+
+import java.util.List;
+
+public record ProductStockReservationFailedEvent(
+        String orderNumber,
+        List<StockOrderItemDto> items,
+        String reasonCode,
+        String reasonMessage
+) {
+}

--- a/market-service/build.gradle
+++ b/market-service/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // JWT

--- a/market-service/src/main/java/com/thock/back/market/app/MarketCompensateStockReservationFailureUseCase.java
+++ b/market-service/src/main/java/com/thock/back/market/app/MarketCompensateStockReservationFailureUseCase.java
@@ -1,0 +1,53 @@
+package com.thock.back.market.app;
+
+import com.thock.back.global.exception.CustomException;
+import com.thock.back.global.exception.ErrorCode;
+import com.thock.back.market.domain.Order;
+import com.thock.back.market.domain.OrderCancelHistory;
+import com.thock.back.market.out.repository.OrderCancelHistoryRepository;
+import com.thock.back.market.out.repository.OrderRepository;
+import com.thock.back.shared.market.domain.CancelReasonType;
+import com.thock.back.shared.product.event.ProductStockReservationFailedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MarketCompensateStockReservationFailureUseCase {
+
+    private final OrderRepository orderRepository;
+    private final OrderCancelHistoryRepository orderCancelHistoryRepository;
+
+    @Transactional
+    public void compensate(ProductStockReservationFailedEvent event) {
+        Order order = orderRepository.findByOrderNumber(event.orderNumber())
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        String reasonDetail = String.format(
+                "재고 예약 실패로 인한 시스템 취소: %s",
+                event.reasonMessage()
+        );
+
+        boolean cancelled = order.cancelBecauseStockReservationFailed(reasonDetail);
+        if (!cancelled) {
+            return;
+        }
+
+        var histories = order.getItems().stream()
+                .map(item -> OrderCancelHistory.ofSystemCancel(
+                        order,
+                        item,
+                        CancelReasonType.STOCK_RESERVATION_FAILED,
+                        reasonDetail
+                ))
+                .toList();
+
+        orderCancelHistoryRepository.saveAll(histories);
+
+        log.warn("재고 예약 실패 보상 처리 완료: orderNumber={}, reasonCode={}",
+                event.orderNumber(), event.reasonCode());
+    }
+}

--- a/market-service/src/main/java/com/thock/back/market/app/MarketFacade.java
+++ b/market-service/src/main/java/com/thock/back/market/app/MarketFacade.java
@@ -7,6 +7,7 @@ import com.thock.back.market.in.dto.req.CartItemAddRequest;
 import com.thock.back.market.in.dto.req.OrderCreateRequest;
 import com.thock.back.shared.market.domain.CancelReasonType;
 import com.thock.back.shared.product.event.ProductEvent;
+import com.thock.back.shared.product.event.ProductStockReservationFailedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ public class MarketFacade {
     private final MarketCompleteRefundUseCase marketCompleteRefundUseCase; // 환불
     private final MarketConfirmOrderUseCase marketConfirmOrderUseCase; // 구매 확정
     private final MarketSyncCartProductViewUseCase marketSyncCartProductViewUseCase;
+    private final MarketCompensateStockReservationFailureUseCase marketCompensateStockReservationFailureUseCase;
 
     // 조회 전용
     private final CartService cartService;
@@ -115,5 +117,10 @@ public class MarketFacade {
     @Transactional(readOnly = true)
     public List<InternalOrderSummaryResponse> getRecentOrderSummaries(Long memberId, int limit) {
         return orderService.getRecentOrderSummaries(memberId, limit);
+    }
+
+    @Transactional
+    public void compensateStockReservationFailure(ProductStockReservationFailedEvent event) {
+        marketCompensateStockReservationFailureUseCase.compensate(event);
     }
 }

--- a/market-service/src/main/java/com/thock/back/market/domain/Order.java
+++ b/market-service/src/main/java/com/thock/back/market/domain/Order.java
@@ -51,6 +51,10 @@ public class Order extends BaseIdAndTime {
     @Column(nullable = false)
     private OrderState state;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private OrderStockReservationState stockReservationState = OrderStockReservationState.NOT_REQUESTED;
+
     @Version
     private Long version;
 
@@ -78,6 +82,7 @@ public class Order extends BaseIdAndTime {
         this.buyer = buyer;
         this.orderNumber = generateOrderNumber();
         this.state = OrderState.PENDING_PAYMENT;
+        this.stockReservationState = OrderStockReservationState.NOT_REQUESTED;
         this.zipCode = zipCode;
         this.baseAddress = baseAddress;
         this.detailAddress = detailAddress;
@@ -173,6 +178,8 @@ public class Order extends BaseIdAndTime {
 
         // Settlement 이벤트 발행 (결제 완료)
         publishSettlementEvent(SettlementEventType.PAYMENT_COMPLETED);
+
+        this.stockReservationState = OrderStockReservationState.RESERVE_REQUESTED;
         // Product 재고 예약 이벤트 발행
         publishStockEvent(StockEventType.RESERVE, this.items);
     }
@@ -334,7 +341,12 @@ public class Order extends BaseIdAndTime {
         if (!refundedItems.isEmpty()) {
             publishEvent(new MarketOrderSettlementEvent(refundedItems));
             log.info("📊 환불 Settlement 이벤트 발행: orderNumber={}, count={}", orderNumber, refundedItems.size());
-            publishStockEvent(StockEventType.RELEASE, refundedOrderItems);
+
+            if (!isStockReservationFailed()) {
+                publishStockEvent(StockEventType.RELEASE, refundedOrderItems);
+            } else {
+                log.info("재고 예약 실패 주문이므로 재고 해제 이벤트 생략: orderNumber={}", orderNumber);
+            }
         }
 
         if (!confirmedItems.isEmpty()) {
@@ -527,5 +539,29 @@ public class Order extends BaseIdAndTime {
                 getOrderNumber(),
                 getTotalSalePrice()
         );
+    }
+
+    public boolean cancelBecauseStockReservationFailed(String reasonDetail) {
+        if (this.stockReservationState == OrderStockReservationState.RESERVE_FAILED) {
+            log.info("이미 재고 예약 실패로 보상 처리된 주문: orderNumber={}", orderNumber);
+            return false;
+        }
+
+        if (this.state == OrderState.CANCELLED || this.state == OrderState.REFUNDED) {
+            this.stockReservationState = OrderStockReservationState.RESERVE_FAILED;
+            return false;
+        }
+
+        if (!this.state.isCancellable()) {
+            throw new CustomException(ErrorCode.ORDER_CANNOT_CANCEL);
+        }
+
+        this.stockReservationState = OrderStockReservationState.RESERVE_FAILED;
+        this.cancel(CancelReasonType.STOCK_RESERVATION_FAILED, reasonDetail);
+        return true;
+    }
+
+    public boolean isStockReservationFailed() {
+        return this.stockReservationState == OrderStockReservationState.RESERVE_FAILED;
     }
 }

--- a/market-service/src/main/java/com/thock/back/market/domain/OrderCancelHistory.java
+++ b/market-service/src/main/java/com/thock/back/market/domain/OrderCancelHistory.java
@@ -61,9 +61,15 @@ public class OrderCancelHistory extends BaseIdAndTime {
         return new OrderCancelHistory(order, orderItem, cancelReasonType, cancelReasonDetail, CancelledBy.USER);
     }
 
+    public static OrderCancelHistory ofSystemCancel(Order order, OrderItem orderItem,
+                                                    CancelReasonType cancelReasonType,
+                                                    String cancelReasonDetail) {
+        return new OrderCancelHistory(order, orderItem, cancelReasonType, cancelReasonDetail, CancelledBy.SYSTEM);
+    }
+
     // 팩토리 메서드: 시스템 취소
     public static OrderCancelHistory ofSystemCancel(Order order, OrderItem orderItem,
                                                     CancelReasonType cancelReasonType) {
-        return new OrderCancelHistory(order, orderItem, cancelReasonType, "시스템에서 취소(타임 아웃 등)", CancelledBy.SYSTEM);
+        return ofSystemCancel(order, orderItem, cancelReasonType, "시스템에서 취소(타임 아웃 등)");
     }
 }

--- a/market-service/src/main/java/com/thock/back/market/domain/OrderStockReservationState.java
+++ b/market-service/src/main/java/com/thock/back/market/domain/OrderStockReservationState.java
@@ -1,0 +1,7 @@
+package com.thock.back.market.domain;
+
+public enum OrderStockReservationState {
+    NOT_REQUESTED,
+    RESERVE_REQUESTED,
+    RESERVE_FAILED
+}

--- a/market-service/src/main/java/com/thock/back/market/in/MarketKafkaListener.java
+++ b/market-service/src/main/java/com/thock/back/market/in/MarketKafkaListener.java
@@ -11,6 +11,7 @@ import com.thock.back.shared.member.event.MemberModifiedEvent;
 import com.thock.back.shared.payment.event.PaymentCompletedEvent;
 import com.thock.back.shared.payment.event.PaymentRefundCompletedEvent;
 import com.thock.back.shared.product.event.ProductEvent;
+import com.thock.back.shared.product.event.ProductStockReservationFailedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
@@ -139,6 +140,29 @@ public class MarketKafkaListener {
             inboundMetrics.recordProcessed(KafkaTopics.PRODUCT_CHANGED);
         } catch (Exception e) {
             inboundMetrics.recordFailed(KafkaTopics.PRODUCT_CHANGED);
+            throw e;
+        }
+    }
+
+    @KafkaListener(topics = KafkaTopics.PRODUCT_STOCK_RESERVATION_FAILED, groupId = "market-service")
+    @Transactional
+    public void handle(ProductStockReservationFailedEvent event) {
+        inboundMetrics.recordReceived(KafkaTopics.PRODUCT_STOCK_RESERVATION_FAILED);
+        if (!shouldProcess(
+                KafkaTopics.PRODUCT_STOCK_RESERVATION_FAILED,
+                keyResolver.productStockReservationFailed(event)
+        )) {
+            inboundMetrics.recordDuplicate(KafkaTopics.PRODUCT_STOCK_RESERVATION_FAILED);
+            return;
+        }
+
+        try {
+            log.warn("Received ProductStockReservationFailedEvent via Kafka: orderNumber={}, reasonCode={}",
+                    event.orderNumber(), event.reasonCode());
+            marketFacade.compensateStockReservationFailure(event);
+            inboundMetrics.recordProcessed(KafkaTopics.PRODUCT_STOCK_RESERVATION_FAILED);
+        } catch (Exception e) {
+            inboundMetrics.recordFailed(KafkaTopics.PRODUCT_STOCK_RESERVATION_FAILED);
             throw e;
         }
     }

--- a/market-service/src/main/java/com/thock/back/market/in/idempotency/MarketInboundEventIdempotencyKeyResolver.java
+++ b/market-service/src/main/java/com/thock/back/market/in/idempotency/MarketInboundEventIdempotencyKeyResolver.java
@@ -5,6 +5,7 @@ import com.thock.back.shared.member.event.MemberModifiedEvent;
 import com.thock.back.shared.payment.event.PaymentCompletedEvent;
 import com.thock.back.shared.payment.event.PaymentRefundCompletedEvent;
 import com.thock.back.shared.product.event.ProductEvent;
+import com.thock.back.shared.product.event.ProductStockReservationFailedEvent;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -38,6 +39,13 @@ public class MarketInboundEventIdempotencyKeyResolver {
                 "payment-refund-completed",
                 event.dto().orderId(),
                 String.valueOf(event.dto().amount())
+        );
+    }
+
+    public String productStockReservationFailed(ProductStockReservationFailedEvent event) {
+        return String.join(":",
+                "product-stock-reservation-failed",
+                event.orderNumber()
         );
     }
 

--- a/market-service/src/main/resources/application-test.yml
+++ b/market-service/src/main/resources/application-test.yml
@@ -9,10 +9,10 @@ spring:
       auto-startup: false
 
   datasource:
-    driver-class-name: ${TEST_DB_DRIVER:org.h2.Driver}
-    url: ${TEST_DB_URL:jdbc:h2:mem:market_test;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
-    username: ${TEST_DB_USERNAME:sa}
-    password: ${TEST_DB_PASSWORD:}
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:market_test;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
 
   flyway:
     enabled: false
@@ -22,7 +22,7 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
-        dialect: ${TEST_DB_DIALECT:org.hibernate.dialect.H2Dialect}
+        dialect: org.hibernate.dialect.H2Dialect
         generate_statistics: true
 
   task:

--- a/market-service/src/main/resources/application-test.yml
+++ b/market-service/src/main/resources/application-test.yml
@@ -9,9 +9,10 @@ spring:
       auto-startup: false
 
   datasource:
-    url: ${TEST_DB_URL:jdbc:mysql://localhost:3307/test_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
-    username: ${TEST_DB_USERNAME:test}
-    password: ${TEST_DB_PASSWORD:test}
+    driver-class-name: ${TEST_DB_DRIVER:org.h2.Driver}
+    url: ${TEST_DB_URL:jdbc:h2:mem:market_test;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+    username: ${TEST_DB_USERNAME:sa}
+    password: ${TEST_DB_PASSWORD:}
 
   flyway:
     enabled: false
@@ -21,6 +22,7 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
+        dialect: ${TEST_DB_DIALECT:org.hibernate.dialect.H2Dialect}
         generate_statistics: true
 
   task:

--- a/market-service/src/main/resources/db/migration/V2__add_order_stock_reservation_state.sql
+++ b/market-service/src/main/resources/db/migration/V2__add_order_stock_reservation_state.sql
@@ -1,0 +1,24 @@
+SET @table_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'market_orders'
+);
+
+SET @column_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'market_orders'
+      AND COLUMN_NAME = 'stock_reservation_state'
+);
+
+SET @sql := IF(
+    @table_exists = 1 AND @column_exists = 0,
+    'ALTER TABLE market_orders ADD COLUMN stock_reservation_state varchar(50) NOT NULL DEFAULT ''NOT_REQUESTED''',
+    'SELECT 1'
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/product-service/src/main/resources/application-test.yml
+++ b/product-service/src/main/resources/application-test.yml
@@ -10,10 +10,10 @@ spring:
       auto-startup: false
 
   datasource:
-    url: ${TEST_DB_URL:jdbc:mysql://localhost:3307/test_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
-    username: ${TEST_DB_USERNAME:test}
-    password: ${TEST_DB_PASSWORD:test}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: ${TEST_DB_DRIVER:org.h2.Driver}
+    url: ${TEST_DB_URL:jdbc:h2:mem:product_test;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+    username: ${TEST_DB_USERNAME:sa}
+    password: ${TEST_DB_PASSWORD:}
 
   flyway:
     enabled: false
@@ -21,6 +21,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: ${TEST_DB_DIALECT:org.hibernate.dialect.H2Dialect}
 
   batch:
     job:

--- a/product-service/src/main/resources/application-test.yml
+++ b/product-service/src/main/resources/application-test.yml
@@ -10,10 +10,10 @@ spring:
       auto-startup: false
 
   datasource:
-    driver-class-name: ${TEST_DB_DRIVER:org.h2.Driver}
-    url: ${TEST_DB_URL:jdbc:h2:mem:product_test;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
-    username: ${TEST_DB_USERNAME:sa}
-    password: ${TEST_DB_PASSWORD:}
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:product_test;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
 
   flyway:
     enabled: false
@@ -23,7 +23,7 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
-        dialect: ${TEST_DB_DIALECT:org.hibernate.dialect.H2Dialect}
+        dialect: org.hibernate.dialect.H2Dialect
 
   batch:
     job:

--- a/settlement-service/build.gradle
+++ b/settlement-service/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // JWT

--- a/settlement-service/src/main/resources/application-test.yml
+++ b/settlement-service/src/main/resources/application-test.yml
@@ -9,13 +9,17 @@ spring:
       auto-startup: false
 
   datasource:
-    url: ${TEST_DB_URL:jdbc:mysql://localhost:3307/test_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
-    username: ${TEST_DB_USERNAME:test}
-    password: ${TEST_DB_PASSWORD:test}
+    driver-class-name: ${TEST_DB_DRIVER:org.h2.Driver}
+    url: ${TEST_DB_URL:jdbc:h2:mem:settlement_test;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+    username: ${TEST_DB_USERNAME:sa}
+    password: ${TEST_DB_PASSWORD:}
 
   jpa:
     hibernate:
       ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: ${TEST_DB_DIALECT:org.hibernate.dialect.H2Dialect}
 
 jwt:
   secret: thock-test-jwt-secret-key-which-is-long-enough-32chars

--- a/settlement-service/src/main/resources/application-test.yml
+++ b/settlement-service/src/main/resources/application-test.yml
@@ -9,17 +9,17 @@ spring:
       auto-startup: false
 
   datasource:
-    driver-class-name: ${TEST_DB_DRIVER:org.h2.Driver}
-    url: ${TEST_DB_URL:jdbc:h2:mem:settlement_test;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
-    username: ${TEST_DB_USERNAME:sa}
-    password: ${TEST_DB_PASSWORD:}
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:settlement_test;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
 
   jpa:
     hibernate:
       ddl-auto: create-drop
     properties:
       hibernate:
-        dialect: ${TEST_DB_DIALECT:org.hibernate.dialect.H2Dialect}
+        dialect: org.hibernate.dialect.H2Dialect
 
 jwt:
   secret: thock-test-jwt-secret-key-which-is-long-enough-32chars


### PR DESCRIPTION
## 관련 이슈
Closes #70 

## 변경 내용
- `ProductStockReservationFailedEvent`와 `product.stock.reservation.failed` 토픽 상수를 추가했습니다.
- 주문에 `OrderStockReservationState`를 추가해 재고 예약 요청/실패 상태를 기록하도록 했습니다.
- 재고 예약 실패 이벤트를 수신하는 Market Kafka Listener와 멱등성 키 생성 로직을 추가했습니다.
- 재고 예약 실패 시 주문을 시스템 취소하고 기존 환불 요청 이벤트를 발행하는 보상 유스케이스를 추가했습니다.
- 재고 예약 실패 주문은 환불 완료 처리 시 재고 RELEASE 이벤트를 발행하지 않도록 했습니다.
- `stock_reservation_state` 컬럼 추가를 위한 Flyway 마이그레이션을 추가했습니다.
- 테스트 기본 DB를 H2 in-memory로 설정해 로컬 외부 MySQL 없이 빌드가 가능하도록 보강했습니다.

## 확인 내용
- `./gradlew build` 성공